### PR TITLE
Adding two simple wrapper scripts to run OpenMMDL on the slurm system

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ There are two Systems prepared for the testing of the simulation.
 
     openmmdl-simulation -f 5wyz_testing_simulation -t ~/OpenMMDL/openmmdl_simulation/testing_sytems/5wyz_solvent/5wyz-moe-processed_openMMDL.pdb -s ~/OpenMMDL/openmmdl_simulation/testing_sytems/5wyz_solvent/5wyz_simulation.py -l  ~/OpenMMDL/openmmdl_simulation/testing_sytems/5wyz_solvent/5VF.sdf
 
-## Running OpenMMDL-Simulations using slurm in multiple replicas
+## Running OpenMMDL-Simulations using slurm (multiple replicas are possible)
 
 Two scripts are needed to run simulations via slurm. Start using the runOpenMM_slurm.sh bash script when being in the repository folder. It has several inputs. For help just type: 
 

--- a/README.md
+++ b/README.md
@@ -91,12 +91,15 @@ There are two Systems prepared for the testing of the simulation.
 ## Running OpenMMDL-Simulations using slurm in multiple replicas
 
 Two scripts are needed to run simulations via slurm. Start using the runOpenMM_slurm.sh bash script when being in the repository folder. It has several inputs. For help just type: 
+
     Bash runOpenMM_slurm.sh
+    
 without any flags, it will list the flags needed. The simplest way to run a simulation is to use the "-i" flag, which takes an input directory including the simulationscript, the topology and optionally the ligand file and it will create the outputs folder within the given directory. NOTE: ake sure only one topology is present in the input folder, so that it finds it automatically.
 
 The script calls a second script (you don't need to do that) that is used for slurms "sbatch" command to run multiple replicas. The second script can be left where it is and named how it is (SlurmWrap.sh). 
 
 One example line of how to start a five replicas on cn-gpus would be: 
+
     bash runOpenMM.sh -i /mdspace/leon-moveWIP/Ligand-search-stability-check/ALk2R206H-D207Q-backmut/simulation -n 5 -c
 
 ## Copyright

--- a/README.md
+++ b/README.md
@@ -88,6 +88,16 @@ There are two Systems prepared for the testing of the simulation.
 
     openmmdl-simulation -f 5wyz_testing_simulation -t ~/OpenMMDL/openmmdl_simulation/testing_sytems/5wyz_solvent/5wyz-moe-processed_openMMDL.pdb -s ~/OpenMMDL/openmmdl_simulation/testing_sytems/5wyz_solvent/5wyz_simulation.py -l  ~/OpenMMDL/openmmdl_simulation/testing_sytems/5wyz_solvent/5VF.sdf
 
+## Running OpenMMDL-Simulations using slurm in multiple replicas
+
+Two scripts are needed to run simulations via slurm. Start using the runOpenMM_slurm.sh bash script when being in the repository folder. It has several inputs. For help just type: 
+    Bash runOpenMM_slurm.sh
+without any flags, it will list the flags needed. The simplest way to run a simulation is to use the "-i" flag, which takes an input directory including the simulationscript, the topology and optionally the ligand file and it will create the outputs folder within the given directory. NOTE: ake sure only one topology is present in the input folder, so that it finds it automatically.
+
+The script calls a second script (you don't need to do that) that is used for slurms "sbatch" command to run multiple replicas. The second script can be left where it is and named how it is (SlurmWrap.sh). 
+
+One example line of how to start a five replicas on cn-gpus would be: 
+    bash runOpenMM.sh -i /mdspace/leon-moveWIP/Ligand-search-stability-check/ALk2R206H-D207Q-backmut/simulation -n 5 -c
 
 ## Copyright
 Copyright (c) 2022, Valerij Talagayev & Yu Chen (Wolber lab)

--- a/SlurmWrap.sh
+++ b/SlurmWrap.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+# Leons simple wrap for openmm-run
+
+while getopts ":t:f:s:l:" i; do
+        case "${i}" in
+        t)
+                topology=$OPTARG
+        ;;
+        f)
+                output_dir=$OPTARG
+        ;;
+        s)
+                simulationscript=$OPTARG
+        ;;
+        l)
+                ligand=$OPTARG
+        ;;
+        esac
+done
+$(python3 ~/OpenMMDL/openmmdl_simulation/openmmdlsimulation.py -t $topology -f $output_dir -s $simulationscript -l $ligand)

--- a/runOpenMM_slurm.sh
+++ b/runOpenMM_slurm.sh
@@ -1,0 +1,89 @@
+#!/bin/bash
+# Leons wrap for openmm-run
+# currently quite hacky
+# the paths must be absolute paths.
+
+
+usage() {
+        echo ""
+        echo "Please make sure all required parameters are given"
+        echo "Usage: $0 <OPTIONS>"
+        echo "Required Parameters are EITHER:"
+        echo "-t <topology>         Path to the input topology file (meaning the protein, e.g. PDB)"
+        echo "-f <output_dir>       Path to a directory that will store the results!"
+        echo "-s <simulationscript> Path to the simulationscript. This is the python script which is the output of the preparational step"
+        echo "OR instead of -f -s -t:"
+        echo "-i <inputdir> 	    A directory containing the topology file as a pdb, the script file (python), and possibly a ligand file!"
+        echo "OPTIONAL STUFF:"
+        echo "-l <ligand> 	    Path to the ligand SDF file in case you are simulating a ligand in the complex!"
+        echo "-n <REPLICA> 	    Number of replicas to be run (default = 1)"
+        echo "-g <GPUs> 	    specify the GPUs that should be used (default is all-gpu)"
+        echo "-c 	 	    If -c is added to the command line, the cn-gpus are used by default"
+        echo ""
+        echo "an example command using the -i option instead of the -f -l -s -t option could look like: "
+        echo "bash runOpenMM.sh -i /mdspace/leon-moveWIP/Ligand-search-stability-check/ALk2R206H-D207Q-backmut/simulation -n 5 -c"
+        echo ""
+        exit 1
+}
+
+
+
+while getopts ":n:t:f:i:s:l:g:c" i; do
+        case "${i}" in
+        t)
+                topology=$OPTARG
+        ;;
+        f)
+                output_dir=$OPTARG
+        ;;
+        s)
+                simulationscript=$OPTARG
+        ;;
+        l)
+                ligand=$OPTARG
+        ;;
+        n)
+                REPLICA=$OPTARG
+        ;;
+        g)
+                GPUs=$OPTARG
+        ;;
+        c)
+                GPUs=cn-gpu
+        ;;
+        i)
+                inputfolder=$OPTARG
+                topology=$inputfolder/*.pdb
+                simulationscript=$inputfolder/OpenMMDL_Simulation.py
+                ligand=$inputfolder/*.sdf
+                mkdir $inputfolder/outputs
+                output_dir=$inputfolder/outputs
+        ;;
+        esac
+done
+
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+echo $GPUs
+if [[ "$topology" == "" || "$output_dir" == "" || "$simulationscript" == "" ]] ; then
+    usage
+fi
+
+if [[ "$GPUs" == "" ]] ; then
+    GPUs=all-gpu
+fi
+echo $GPUs
+if [[ "$REPLICA" == "" ]] ; then
+    REPLICA=1
+fi
+# Run AlphaFold with required parameters
+cd $output_dir
+for counter in $(seq 0 $((REPLICA - 1)))
+do
+  if [ -d "$counter" ]; then
+    rm -r $counter
+  fi
+  mkdir $counter
+  echo "Submitting replica ${counter} ..."
+  sbatch -p $GPUs --nodes=1 --gres=gpu:1 $SCRIPT_DIR/SlurmWrap.sh -t $topology -f $output_dir/$counter -s $simulationscript -l $ligand
+done
+


### PR DESCRIPTION
I've added scripts to run OpenMM simulations on our slurm system:
runOpenMM_slurm.sh
SlurmWrap.sh

and updated the readme.md documentation. 

The runOpenMM_slurm.sh can now be used to easily run OpenMMDL jobs on our slurm system. 
The SlurmWrap.sh should not be touched, it is just needed because the "sbatch" function of slurm needs a bash script to run multiple replicas. 

Within these there is now also the lazy option to only provide an input directory path instead of all the file paths individually... It will find the topology, the simulations script, the ligand file and create an output directory in this case. It is quite hacky and works only when only one topology is present in the given folder... Maybe we can optimize this to automatically find the prepared topology and not the raw topology from before preparation... 