### PR TITLE
barcode_generation fix for some cases

### DIFF
--- a/openmmdl/openmmdl_analysis/barcode_generation.py
+++ b/openmmdl/openmmdl_analysis/barcode_generation.py
@@ -44,7 +44,7 @@ def waterids_barcode_generator(df, interaction):
     waterid_barcode = []
     for index, row in df.iterrows():
         if row[interaction] == 1:
-            water_id_list.append(int(row['WATER_IDX']))
+            water_id_list.append(int(float(row['WATER_IDX'])))
     
     barcode = barcodegeneration(df, interaction)
     


### PR DESCRIPTION
barcode_generation with the water molecules had some edge cases where no integer could be generated, dirty fix by converting to float before converting to an integer works. 

the error was: 

ValueError: invalid literal for int() with base 10: '4781.0'  which did not occur when in other cases with water-IDs like 4805.0, which is strange. however conversion into float first fixed this issue