### PR TITLE
Fixing of Errors with Figures

### DIFF
--- a/openmmdl/openmmdl_analysis/openmmdlanalysis.py
+++ b/openmmdl/openmmdl_analysis/openmmdlanalysis.py
@@ -703,7 +703,7 @@ def main():
 
                 # Convert the svg to an png
                 cairosvg.svg2png(
-                    url=f"{binding_mode}.{fig_type}", write_to=f"{binding_mode}.png"
+                    url=f"{binding_mode}.svg", write_to=f"{binding_mode}.png"
                 )
 
                 # Generate the interactions legend and combine it with the ligand png

--- a/openmmdl/openmmdl_analysis/openmmdlanalysis.py
+++ b/openmmdl/openmmdl_analysis/openmmdlanalysis.py
@@ -716,8 +716,12 @@ def main():
                 merged_image_paths, "all_binding_modes_arranged.png"
             )
             generate_ligand_image(
-                ligand, "complex.pdb", "lig_no_h.pdb", "lig.smi", f"ligand_numbering.{fig_type}"
+                ligand, "complex.pdb", "lig_no_h.pdb", "lig.smi", f"ligand_numbering.svg"
             )
+            if fig_type == "png":
+                cairosvg.svg2png(
+                    url=f"ligand_numbering.svg", write_to=f"ligand_numbering.png"
+                )
             print("\033[1mBinding mode figure generated\033[0m")
     except Exception as e:
         print(f"Ligand could not be recognized, use the -l option")


### PR DESCRIPTION
Fixes:

- Change in RDKit figure to SVG, since it is the only format it is written out
- Additional Case for Ligand Numbering Figure, if PNG is selected