### PR TITLE
Change to RDKitConverter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ The rules for this file:
 talagayev, NDoering99
 
 ### Added
+- Changed to the use of RDKitConverter for Ligand recognition without -l flag in openmmdl_analysis (2025-04-10)
 - Addition of MDontallo Visualization (2025-04-11)
 - Addition of SMIRNOFF small molecule force field (2025-04-10, Issue #76)
 - Addition of PyMOL support for visualization (2025-04-10)

--- a/openmmdl/openmmdl_analysis/openmmdlanalysis.py
+++ b/openmmdl/openmmdl_analysis/openmmdlanalysis.py
@@ -257,8 +257,8 @@ def main():
     print("\033[1mFiles are preprocessed\033[0m")
 
     if ligand_sdf == None:
-        preprocessor.extract_and_save_ligand_as_sdf(topology, "./lig.sdf", ligand)
-        ligand_sdf = "./lig.sdf"
+        preprocessor.extract_and_save_ligand_as_sdf(topology, "./ligand_prepared.sdf", ligand)
+        ligand_sdf = "./ligand_prepared.sdf"
 
     if not pdb_md:
         pdb_md = mda.Universe(topology, trajectory)
@@ -325,7 +325,6 @@ def main():
             ligand_rings.append(current_ring)
         print("\033[1mLigand ring data gathered\033[0m")
 
-        preprocessor.convert_ligand_to_smiles(ligand_sdf, output_smi="lig.smi")
     if peptide != None:
         ligand_rings = None
 
@@ -501,14 +500,10 @@ def main():
                 binding_site[binding_mode] = values
                 occurrence_count = top_10_nodes_with_occurrences[binding_mode]
                 occurrence_percent = 100 * occurrence_count / total_frames
-                with open("lig.smi", "r") as file:
-                    reference_smiles = (
-                        file.read().strip()
-                    )  # Read the SMILES from the file and remove any leading/trailing whitespace
-                reference_mol = Chem.MolFromSmiles(reference_smiles)
-                prepared_ligand = AllChem.AssignBondOrdersFromTemplate(
-                    reference_mol, lig_rd
-                )
+                # Convert ligand to RDKit with Converter
+                lig_atoms = complex_lig.convert_to("RDKIT")
+                # Remove Hydrogens and get 2D representation
+                prepared_ligand = Chem.RemoveAllHs(lig_atoms)
                 # Generate 2D coordinates for the molecule
                 AllChem.Compute2DCoords(prepared_ligand)
                 split_data = interaction_processor.split_interaction_data(values)
@@ -641,7 +636,6 @@ def main():
                 ligand,
                 "complex.pdb",
                 "lig_no_h.pdb",
-                "lig.smi",
                 f"ligand_numbering.svg",
                 fig_type,
             )

--- a/openmmdl/openmmdl_analysis/preprocessing.py
+++ b/openmmdl/openmmdl_analysis/preprocessing.py
@@ -5,10 +5,8 @@ import re
 import rdkit
 import mdtraj as md
 from rdkit import Chem
-from rdkit.Chem import Draw
-from rdkit.Chem import AllChem
+from rdkit.Chem import Draw, AllChem, SDWriter
 from rdkit.Chem.Draw import rdMolDraw2D
-from openbabel import pybel
 
 
 class Preprocessing:
@@ -99,26 +97,6 @@ class Preprocessing:
         """
         return [atom_idx + lig_index for atom_idx in ring]
 
-    def convert_ligand_to_smiles(self, input_sdf, output_smi):
-        """Converts ligand structures from an SDF file to SMILES :) format
-
-        Args:
-            input_sdf (str): Path to the SDF file with the ligand that wll be converted.
-            output_smi (str): Path to the output SMILES files.
-        """
-        # Create a molecule supplier from an SDF file
-        mol_supplier = Chem.SDMolSupplier(input_sdf)
-
-        # Open the output SMILES file for writing
-        with open(output_smi, "w") as output_file:
-            # Iterate through molecules and convert each to SMILES
-            for mol in mol_supplier:
-                if mol is not None:  # Make sure the molecule was successfully read
-                    smiles = Chem.MolToSmiles(mol)
-                    output_file.write(smiles + "\n")
-                else:
-                    print("nono")
-
     def process_pdb_file(self, input_pdb_filename):
         """Process a PDB file to make it compatible with the openmmdl_analysis package.
 
@@ -163,17 +141,13 @@ class Preprocessing:
             )
             return
 
-        # Create a new Universe with only the ligand
-        ligand_universe = mda.Merge(ligand_atoms)
+        #Using RDKit Converter to get SDF File
+        lig_atoms = ligand_atoms.convert_to("RDKIT")
 
-        # Save the ligand Universe as a PDB file
-        ligand_universe.atoms.write("lig.pdb")
-
-        # use openbabel to convert pdb to sdf
-        mol = next(pybel.readfile("pdb", "lig.pdb"))
-        mol.write("sdf", output_filename, overwrite=True)
-        # remove the temporary pdb file
-        os.remove("lig.pdb")
+        #Write out the SDF file
+        writer = SDWriter(output_filename)
+        writer.write(lig_atoms)
+        writer.close()
 
     def renumber_atoms_in_residues(self, input_pdb_file, output_pdb_file, lig_name):
         """Renumer the atoms of the ligand in the topology PDB file.

--- a/openmmdl/openmmdl_analysis/rdkit_figure_generation.py
+++ b/openmmdl/openmmdl_analysis/rdkit_figure_generation.py
@@ -15,7 +15,6 @@ class LigandImageGenerator:
         ligand_name,
         complex_pdb_file,
         ligand_no_h_pdb_file,
-        smiles_file,
         output_svg_filename,
         fig_type="svg",
     ):
@@ -26,14 +25,12 @@ class LigandImageGenerator:
             ligand_name (str): Name of the ligand in the protein-ligand complex topology.
             complex_pdb_file (str): Path to the protein-ligand complex PDB file.
             ligand_no_h_pdb_file (str): Path to the ligand PDB file without hydrogens.
-            smiles_file (str): Path to the SMILES file with the reference ligand.
             output_svg_filename (str): Name of the output SVG file.
             fig_type (str): Type of the output figure. Can be "svg" or "png".
         """
         self.ligand_name = ligand_name
         self.complex_pdb_file = complex_pdb_file
         self.ligand_no_h_pdb_file = ligand_no_h_pdb_file
-        self.smiles_file = smiles_file
         self.output_svg_filename = output_svg_filename
         self.fig_type = fig_type
 
@@ -46,19 +43,10 @@ class LigandImageGenerator:
             lig_noh = ligand_no_h.select_atoms("all")
             complex_lig = complex.select_atoms(f"resname {self.ligand_name}")
 
-            # Load ligand from PDB file
-            mol = Chem.MolFromPDBFile(self.ligand_no_h_pdb_file)
-            lig_rd = mol
-
-            # Load reference SMILES
-            with open(self.smiles_file, "r") as file:
-                reference_smiles = file.read().strip()
-            reference_mol = Chem.MolFromSmiles(reference_smiles)
-
-            # Prepare ligand
-            prepared_ligand = AllChem.AssignBondOrdersFromTemplate(
-                reference_mol, lig_rd
-            )
+            # Application of RDKit Converter to obtain rdkit mol of ligand
+            lig_atoms = complex_lig.convert_to("RDKIT")
+            prepared_ligand = Chem.RemoveAllHs(lig_atoms)
+            
             AllChem.Compute2DCoords(prepared_ligand)
 
             # Map atom indices between ligand_no_h and complex

--- a/openmmdl/tests/openmmdl_analysis/test_preprocessing.py
+++ b/openmmdl/tests/openmmdl_analysis/test_preprocessing.py
@@ -219,17 +219,3 @@ def test_increase_ring_indices():
     lig_index = 20
     result = prep.increase_ring_indices(ring=ring, lig_index=lig_index)
     assert result == [23, 24, 25]
-
-
-def test_convert_ligand_to_smiles():
-    # Convert the ligand structure to SMILES in the same directory as the input SDF file
-    prep = Preprocessing()
-    prep.convert_ligand_to_smiles(TEST_LIGAND_FILE, TEST_OUTPUT_FILE)
-
-    # Verify that the output SMILES file was created in the same directory as the input file
-    assert os.path.exists(TEST_OUTPUT_FILE)
-
-    # Optionally, you can also read and validate the content of the output SMILES file
-    with open(TEST_OUTPUT_FILE, "r") as smi_file:
-        smiles_lines = smi_file.readlines()
-        assert len(smiles_lines) > 0  # Check that there are SMILES representations

--- a/openmmdl/tests/openmmdl_analysis/test_rdkit_figure_generation.py
+++ b/openmmdl/tests/openmmdl_analysis/test_rdkit_figure_generation.py
@@ -231,7 +231,7 @@ shutil.copy(smi_file, Path.cwd())
 # Test the generate_ligand_image function
 def test_generate_ligand_image():
     ligand_name = "UNK"
-    image = LigandImageGenerator(ligand_name, "complex.pdb", "lig_no_h.pdb", "lig_no_h.smi", output_image_file)
+    image = LigandImageGenerator(ligand_name, "complex.pdb", "lig_no_h.pdb", output_image_file)
     image.generate_image()
 
     # Assert that the output image file exists


### PR DESCRIPTION
Changes made:

- Change to `RDKitConverter()` instead of `openbabel` for ligand recognition