### PR TITLE
Native glycoprotein support in the OpenMMDL Setup AMBER path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,10 @@ The rules for this file:
 talagayev
 
 ### Added
+- Added native glycoprotein support in `OpenMMDL Setup` AMBER path
+  (2026-05-20, PR#TBD)
+- Added glycan-aware PBC imaging in `OpenMMDL Simulation`
+  postprocessing (2026-05-20, PR#TBD)
 - Added `openmmdl check` for testing correct installation (2026-05-03, PR#207)
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,13 +18,13 @@ The rules for this file:
 ## Version X.X.X
 
 ### Authors
-talagayev
+talagayev, MarvinTaterra
 
 ### Added
 - Added native glycoprotein support in `OpenMMDL Setup` AMBER path
-  (2026-05-20, PR#TBD)
+  (2026-05-20, PR#210)
 - Added glycan-aware PBC imaging in `OpenMMDL Simulation`
-  postprocessing (2026-05-20, PR#TBD)
+  postprocessing (2026-05-20, PR#210)
 - Added `openmmdl check` for testing correct installation (2026-05-03, PR#207)
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -103,6 +103,14 @@ the address displayed in the console window (e.g. http://127.0.0.1:5000).
 Download the processed PDB file and Python script, which will serve as input
 for the **OpenMMDL Simulation** script.
 
+The Amber path additionally supports a **Glycoprotein** receptor mode for
+N-/O-glycosylated proteins. OpenMMDL detects sugar residues (NAG/NDG, BMA,
+MAN, FUC/FUL) by PDB residue name, renames them to GLYCAM-06j-1 conventions,
+and emits explicit glycosidic-bond statements into the generated tleap
+script. Only the common N-glycan core sugars are currently supported;
+unrecognised sugars produce a descriptive error rather than an incorrect
+topology.
+
 ## OpenMMDL Simulation
 
 **OpenMMDL Simulation** starts the MD simulation with the inputs acquired

--- a/docs/openmmdl_setup.rst
+++ b/docs/openmmdl_setup.rst
@@ -102,3 +102,14 @@ The tutorial for the Amber path can be found :doc:`here </tutorial_amber_path>`.
    :align: center
 
 In the table, the first row is the default setting, and the term `other` allows users to type their desired forcefields from those accessible in AmberTools 22.0 into the designated textbox.
+
+**Glycoprotein receptors (Amber path)**
+
+The Amber path additionally offers a *Glycoprotein* receptor type for proteins with covalently attached N- or O-linked glycans. When selected, OpenMMDL Setup:
+
+1. Detects sugar residues by PDB residue name (NAG, NDG, BMA, MAN, FUC, FUL) and finds glycosidic linkages from CONECT records (falling back to a distance scan if absent).
+2. Renames residues and atoms to GLYCAM-06j-1 conventions (e.g. NAG → 0YB / 4YB, MAN → 0MA / 3MA / 6MA, with the trimannose branch point as VMB).
+3. Emits explicit ``bond`` statements for every protein-glycan and glycan-glycan covalent link, injected into the generated ``tleap.in`` after ``loadpdb``.
+4. Sources both the chosen protein force field (e.g. ``leaprc.protein.ff14SB``) and the glycan force field (``leaprc.GLYCAM_06j-1`` by default).
+
+Only the common N-glycan core sugars listed above are currently supported. Unrecognised PDB sugar codes or non-canonical linkage patterns raise a descriptive error; see ``openmmdl/openmmdl_setup/glycoprotein.py`` for the verified GLYCAM tables.

--- a/docs/tutorial_amber_path.rst
+++ b/docs/tutorial_amber_path.rst
@@ -84,7 +84,9 @@ The page consists of three tabs: Receptor, Ligand, and Add Water/Membrane.
 
 1. **Receptor**
 
-Depending on the macromolecule type (Protein, DNA, RNA, or Carbohydrate), users can select the receptor PDB file using the file browser and choose the appropriate force fields.
+Depending on the macromolecule type (Protein, DNA, RNA, Carbohydrate, or Glycoprotein), users can select the receptor PDB file using the file browser and choose the appropriate force fields.
+
+For the **Glycoprotein** option, OpenMMDL Setup detects sugar residues (NAG / NDG, BMA, MAN, FUC / FUL) by PDB residue name, renames the residues and atoms to GLYCAM conventions, and emits explicit ``bond`` statements into the generated ``tleap.in`` so the glycosidic linkages survive into the prmtop. Both the protein and the glycan force fields are sourced. Currently the verified N-glycan core (NAG/NDG, BMA, MAN, FUC/FUL with 0-/3-/4-/6-/3,6-/4,6-linkages) is supported; unrecognised sugars raise a clear error rather than producing an incorrect topology.
 
 .. figure:: /_static/images/tutorials/Amber_Path/receptor.png
    :figwidth: 700px

--- a/openmmdl/openmmdl_setup/glycoprotein.py
+++ b/openmmdl/openmmdl_setup/glycoprotein.py
@@ -1,0 +1,609 @@
+"""Glycan detection and GLYCAM renaming for the OpenMMDL AMBER path.
+
+Supports the common N-glycan core sugars (NAG, NDG, BMA, MAN, FUC, FUL).
+Residue, linkage and atom-name codes were verified against the
+GLYCAM-06j-1 prep/lib files in GLYCAM-Web/gmml; unsupported sugars or
+linkage patterns raise NotImplementedError rather than guessing.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections import defaultdict
+from dataclasses import dataclass
+
+logger = logging.getLogger(__name__)
+
+
+# PDB CCD code -> (sugar letter, anomer letter); "A" = alpha, "B" = beta.
+SUGAR_TABLE: dict[str, tuple[str, str]] = {
+    "NAG": ("Y", "B"),
+    "NDG": ("Y", "A"),
+    "BMA": ("M", "B"),
+    "MAN": ("M", "A"),
+    "FUC": ("f", "A"),
+    "FUL": ("f", "B"),
+}
+
+PDB_SUGAR_RESNAMES: frozenset[str] = frozenset(SUGAR_TABLE.keys())
+
+# Substituted position(s) on a sugar -> GLYCAM linkage code.
+LINKAGE_CODE: dict[tuple[int, ...], str] = {
+    (): "0",
+    (2,): "2",
+    (3,): "3",
+    (4,): "4",
+    (6,): "6",
+    (2, 3): "Z",
+    (2, 4): "Y",
+    (2, 6): "X",
+    (3, 4): "W",
+    (3, 6): "V",
+    (4, 6): "U",
+    (2, 3, 4): "T",
+    (2, 3, 6): "S",
+    (2, 4, 6): "R",
+    (3, 4, 6): "Q",
+    (2, 3, 4, 6): "P",
+}
+
+_HYDROXYL_H_RENAMES = {
+    "HO2": "H2O",
+    "HO3": "H3O",
+    "HO4": "H4O",
+    "HO6": "H6O",
+}
+
+_NAG_ACETYL_RENAMES = {
+    "C7": "C2N",
+    "O7": "O2N",
+    "C8": "CME",
+    "H81": "H1M",
+    "H82": "H2M",
+    "H83": "H3M",
+    "HN2": "H2N",
+}
+
+# PDB CCD -> GLYCAM atom-name renames, keyed by original residue name.
+SUGAR_ATOM_RENAME: dict[str, dict[str, str]] = {
+    "NAG": {**_HYDROXYL_H_RENAMES, **_NAG_ACETYL_RENAMES},
+    "NDG": {**_HYDROXYL_H_RENAMES, **_NAG_ACETYL_RENAMES},
+    "BMA": dict(_HYDROXYL_H_RENAMES),
+    "MAN": dict(_HYDROXYL_H_RENAMES),
+    "FUC": dict(_HYDROXYL_H_RENAMES),
+    "FUL": dict(_HYDROXYL_H_RENAMES),
+}
+
+# A glycosylated Asn is renamed to the GLYCAM NLN template.
+ACCEPTOR_RESIDUE_RENAME: dict[str, str] = {
+    "ASN": "NLN",
+}
+
+ACCEPTOR_ATOM_RENAME: dict[str, dict[str, str]] = {
+    "ASN": {"HD2": "HD21"},
+}
+
+# HD22 on Asn is replaced by the glycosidic bond and is absent from NLN.
+ACCEPTOR_ATOM_DROP: dict[str, frozenset[str]] = {
+    "ASN": frozenset({"HD22"}),
+}
+
+_PROTEIN_ACCEPTORS = {
+    ("ASN", "ND2"),
+    ("SER", "OG"),
+    ("SEP", "OG"),
+    ("THR", "OG1"),
+    ("TPO", "OG1"),
+    ("TYR", "OH"),
+}
+
+PROTEIN_RESNAMES: frozenset[str] = frozenset(
+    [
+        "ALA",
+        "ARG",
+        "ASN",
+        "ASP",
+        "CYS",
+        "GLN",
+        "GLU",
+        "GLY",
+        "HIS",
+        "ILE",
+        "LEU",
+        "LYS",
+        "MET",
+        "PHE",
+        "PRO",
+        "SER",
+        "THR",
+        "TRP",
+        "TYR",
+        "VAL",
+        "HID",
+        "HIE",
+        "HIP",
+        "HSD",
+        "HSE",
+        "HSP",
+        "CYX",
+        "CYM",
+        "ASH",
+        "GLH",
+        "LYN",
+        "SEP",
+        "TPO",
+    ]
+)
+
+
+@dataclass(frozen=True)
+class _Atom:
+    serial: int
+    name: str
+    altloc: str
+    resname: str
+    chain: str
+    resnum: int
+    icode: str
+    x: float
+    y: float
+    z: float
+
+    @property
+    def res_key(self) -> tuple[str, int, str]:
+        return (self.chain, self.resnum, self.icode)
+
+
+def _parse_pdb(pdb_path: str):
+    atoms: list[_Atom] = []
+    by_serial: dict[int, _Atom] = {}
+    conect: set[tuple[int, int]] = set()
+
+    with open(pdb_path, "r") as fh:
+        for line in fh:
+            rec = line[0:6].strip()
+            if rec in ("ATOM", "HETATM"):
+                try:
+                    serial = int(line[6:11])
+                    name = line[12:16].strip()
+                    altloc = line[16:17]
+                    resname = line[17:20].strip()
+                    chain = line[21:22] if len(line) > 21 else " "
+                    if not chain.strip():
+                        chain = " "
+                    resnum = int(line[22:26])
+                    icode = line[26:27] if len(line) > 26 else " "
+                    x = float(line[30:38])
+                    y = float(line[38:46])
+                    z = float(line[46:54])
+                except ValueError:
+                    continue
+                a = _Atom(serial, name, altloc, resname, chain, resnum, icode, x, y, z)
+                atoms.append(a)
+                by_serial[serial] = a
+            elif rec == "CONECT":
+                try:
+                    s = int(line[6:11])
+                except ValueError:
+                    continue
+                for start in (11, 16, 21, 26):
+                    chunk = line[start : start + 5].strip() if len(line) > start else ""
+                    if not chunk:
+                        continue
+                    try:
+                        t = int(chunk)
+                    except ValueError:
+                        continue
+                    if s != t:
+                        conect.add((min(s, t), max(s, t)))
+
+    return atoms, by_serial, sorted(conect)
+
+
+def _distance(a: _Atom, b: _Atom) -> float:
+    dx = a.x - b.x
+    dy = a.y - b.y
+    dz = a.z - b.z
+    return (dx * dx + dy * dy + dz * dz) ** 0.5
+
+
+def detect_glycans(pdb_path: str) -> list[dict]:
+    """Return the sugar residues found in the PDB.
+
+    Each entry has keys ``chain``, ``resnum``, ``icode``, ``resname`` and
+    ``atoms`` (a list of ``(atom_name, serial)`` tuples in file order).
+    """
+    atoms, _by_serial, _conect = _parse_pdb(pdb_path)
+
+    grouped: dict[tuple[str, int, str], dict] = {}
+    order: list[tuple[str, int, str]] = []
+    for a in atoms:
+        if a.resname not in PDB_SUGAR_RESNAMES:
+            continue
+        key = a.res_key
+        if key not in grouped:
+            order.append(key)
+            grouped[key] = {
+                "chain": a.chain,
+                "resnum": a.resnum,
+                "icode": a.icode,
+                "resname": a.resname,
+                "atoms": [],
+            }
+        grouped[key]["atoms"].append((a.name, a.serial))
+
+    return [grouped[k] for k in order]
+
+
+def detect_glycosylation_sites(pdb_path: str) -> list[dict]:
+    """Find protein-glycan covalent links: CONECT records first, then a
+    distance fallback (1.8 A) on acceptor / sugar-C1 atoms."""
+    atoms, by_serial, conect = _parse_pdb(pdb_path)
+
+    sites: list[dict] = []
+    seen: set = set()
+
+    for s, t in conect:
+        if s not in by_serial or t not in by_serial:
+            continue
+        a, b = by_serial[s], by_serial[t]
+        if a.res_key == b.res_key:
+            continue
+        site = _classify_protein_sugar_bond(a, b)
+        if site is None:
+            continue
+        sig = _site_signature(site)
+        if sig not in seen:
+            seen.add(sig)
+            sites.append(site)
+
+    if sites:
+        return sites
+
+    acceptor_atoms = [a for a in atoms if (a.resname, a.name) in _PROTEIN_ACCEPTORS]
+    sugar_c1_atoms = [a for a in atoms if a.resname in PDB_SUGAR_RESNAMES and a.name == "C1"]
+    cutoff = 1.8
+    for acc in acceptor_atoms:
+        for c1 in sugar_c1_atoms:
+            if acc.res_key == c1.res_key:
+                continue
+            if _distance(acc, c1) <= cutoff:
+                site = _make_site(acc, c1)
+                sig = _site_signature(site)
+                if sig not in seen:
+                    seen.add(sig)
+                    sites.append(site)
+
+    return sites
+
+
+def detect_glycan_glycan_links(pdb_path: str, glycans: list[dict] | None = None) -> list[dict]:
+    """Find sugar-sugar covalent links: CONECT records first, then a
+    distance fallback (1.7 A) on C1-O atom pairs across sugar residues."""
+    del glycans  # accepted for API symmetry
+    atoms, by_serial, conect = _parse_pdb(pdb_path)
+
+    links: list[dict] = []
+    seen: set = set()
+
+    for s, t in conect:
+        if s not in by_serial or t not in by_serial:
+            continue
+        a, b = by_serial[s], by_serial[t]
+        if a.res_key == b.res_key:
+            continue
+        if a.resname not in PDB_SUGAR_RESNAMES:
+            continue
+        if b.resname not in PDB_SUGAR_RESNAMES:
+            continue
+        link = _make_glycan_link(a, b)
+        sig = _link_signature(link)
+        if sig not in seen:
+            seen.add(sig)
+            links.append(link)
+
+    if links:
+        return links
+
+    c1_atoms = [a for a in atoms if a.resname in PDB_SUGAR_RESNAMES and a.name == "C1"]
+    o_atoms = [
+        a
+        for a in atoms
+        if a.resname in PDB_SUGAR_RESNAMES
+        and a.name.startswith("O")
+        and a.name not in ("O5",)
+        and _atom_position(a.name) is not None
+    ]
+    cutoff = 1.7
+    for c1 in c1_atoms:
+        for o in o_atoms:
+            if c1.res_key == o.res_key:
+                continue
+            if _distance(c1, o) <= cutoff:
+                link = _make_glycan_link(o, c1)
+                sig = _link_signature(link)
+                if sig not in seen:
+                    seen.add(sig)
+                    links.append(link)
+
+    return links
+
+
+def determine_glycam_names(
+    glycans: list[dict],
+    protein_links: list[dict],
+    glycan_glycan_links: list[dict],
+) -> dict[tuple[str, int], str]:
+    """Map each detected sugar (and glycosylated Asn) to its GLYCAM code.
+
+    Raises NotImplementedError for sugars outside SUGAR_TABLE, non-canonical
+    linkages, or substitution patterns absent from LINKAGE_CODE.
+    """
+    subs: dict[tuple[str, int], set[int]] = defaultdict(set)
+
+    for link in glycan_glycan_links:
+        from_atom = link["from_atom"]
+        to_atom = link["to_atom"]
+        from_key = (link["from_chain"], link["from_resid"])
+        to_key = (link["to_chain"], link["to_resid"])
+
+        from_pos = _atom_position(from_atom)
+        to_pos = _atom_position(to_atom)
+
+        if from_atom == "C1" and to_pos is not None:
+            subs[to_key].add(to_pos)
+        elif to_atom == "C1" and from_pos is not None:
+            subs[from_key].add(from_pos)
+        else:
+            raise NotImplementedError(
+                f"Glycan-glycan link {link!r} does not match the canonical "
+                "C1-to-O sugar linkage pattern. Only standard N-glycan core "
+                "linkages (C1 -> O2/O3/O4/O6) are currently supported."
+            )
+
+    for site in protein_links:
+        if site["sugar_resname"] not in PDB_SUGAR_RESNAMES:
+            raise NotImplementedError(
+                f"Glycosylation site references unsupported sugar "
+                f"{site['sugar_resname']!r}. Supported: "
+                f"{sorted(PDB_SUGAR_RESNAMES)}."
+            )
+
+    rename: dict[tuple[str, int], str] = {}
+
+    for site in protein_links:
+        prot_resname = site["prot_resname"]
+        if prot_resname in ACCEPTOR_RESIDUE_RENAME:
+            rename[(site["prot_chain"], site["prot_resid"])] = ACCEPTOR_RESIDUE_RENAME[
+                prot_resname
+            ]
+    for entry in glycans:
+        resname = entry["resname"]
+        if resname not in SUGAR_TABLE:
+            raise NotImplementedError(
+                f"PDB sugar {resname!r} is not in the supported set "
+                f"({sorted(SUGAR_TABLE.keys())}). Extend SUGAR_TABLE only "
+                "with codes verified against GLYCAM-Web/gmml."
+            )
+        sugar_letter, anomer_letter = SUGAR_TABLE[resname]
+        key = (entry["chain"], entry["resnum"])
+        positions = tuple(sorted(subs.get(key, set())))
+        if positions not in LINKAGE_CODE:
+            raise NotImplementedError(
+                f"Substitution pattern {positions!r} on "
+                f"{resname} {entry['chain']}{entry['resnum']} has no "
+                "verified GLYCAM linkage code. Edit LINKAGE_CODE only "
+                "with entries cross-checked against GLYCAM-Web/gmml."
+            )
+        rename[key] = f"{LINKAGE_CODE[positions]}{sugar_letter}{anomer_letter}"
+
+    return rename
+
+
+def write_renamed_pdb(
+    input_pdb: str,
+    output_pdb: str,
+    rename_map: dict[tuple[str, int], str],
+) -> None:
+    """Write a PDB with glycan / acceptor residues renamed for GLYCAM.
+
+    A ``TER`` is inserted between consecutive different sugar residues so
+    tleap does not auto-bond adjacent terminal sugars; the explicit ``bond``
+    statements from :func:`emit_bond_statements` reconnect the real
+    linkages. ``rename_map`` is the dict from :func:`determine_glycam_names`.
+    """
+    prev_glycan_key: tuple[str, int] | None = None
+    with open(input_pdb, "r") as src, open(output_pdb, "w") as dst:
+        for line in src:
+            if not line.endswith("\n"):
+                line = line + "\n"
+            rec = line[0:6].strip()
+            if rec in ("ATOM", "HETATM"):
+                try:
+                    orig_resname = line[17:20].strip()
+                    chain = line[21:22]
+                    if not chain.strip():
+                        chain = " "
+                    resnum = int(line[22:26])
+                    atom_name = line[12:16].strip()
+                except (IndexError, ValueError):
+                    dst.write(line)
+                    continue
+                key = (chain, resnum)
+                is_sugar_residue = key in rename_map and orig_resname in SUGAR_ATOM_RENAME
+
+                if is_sugar_residue and prev_glycan_key is not None and prev_glycan_key != key:
+                    dst.write("TER\n")
+
+                if key not in rename_map:
+                    prev_glycan_key = None
+                    dst.write(line)
+                    continue
+
+                if atom_name in ACCEPTOR_ATOM_DROP.get(orig_resname, frozenset()):
+                    continue
+
+                new_resname = rename_map[key]
+                renamed_atom = SUGAR_ATOM_RENAME.get(orig_resname, {}).get(
+                    atom_name,
+                    ACCEPTOR_ATOM_RENAME.get(orig_resname, {}).get(atom_name, atom_name),
+                )
+
+                # rewrite the name (12:16) and resname (17:20) fields
+                name_field = _format_atom_name(renamed_atom)
+                resname_field = (new_resname + "   ")[:3]
+                new_line = line[:12] + name_field + line[16:17] + resname_field + line[20:]
+                dst.write(new_line)
+                prev_glycan_key = key if is_sugar_residue else None
+            elif rec == "TER":
+                prev_glycan_key = None
+                dst.write(line)
+            else:
+                dst.write(line)
+
+
+def emit_bond_statements(
+    pdb_path: str,
+    protein_links: list[dict],
+    glycan_glycan_links: list[dict],
+    system_var: str = "system",
+) -> list[str]:
+    """Return tleap ``bond`` statements for the detected linkages.
+
+    Residue indices are the 1-based sequential order in ``pdb_path``; the
+    caller must run tleap on this PDB or a downstream file that preserves
+    residue order (e.g. the output of ``pdb4amber``).
+    """
+    index = _residue_sequential_index(pdb_path)
+    statements: list[str] = []
+
+    for site in protein_links:
+        p_idx = index.get((site["prot_chain"], site["prot_resid"]))
+        s_idx = index.get((site["sugar_chain"], site["sugar_resid"]))
+        if p_idx is None or s_idx is None:
+            continue
+        statements.append(
+            f"bond {system_var}.{p_idx}.{site['prot_atom']} {system_var}.{s_idx}.{site['sugar_atom']}"
+        )
+
+    for link in glycan_glycan_links:
+        f_idx = index.get((link["from_chain"], link["from_resid"]))
+        t_idx = index.get((link["to_chain"], link["to_resid"]))
+        if f_idx is None or t_idx is None:
+            continue
+        statements.append(
+            f"bond {system_var}.{f_idx}.{link['from_atom']} {system_var}.{t_idx}.{link['to_atom']}"
+        )
+
+    return statements
+
+
+def _classify_protein_sugar_bond(a: _Atom, b: _Atom) -> dict | None:
+    if (a.resname, a.name) in _PROTEIN_ACCEPTORS and b.resname in PDB_SUGAR_RESNAMES:
+        prot, sugar = a, b
+    elif (b.resname, b.name) in _PROTEIN_ACCEPTORS and a.resname in PDB_SUGAR_RESNAMES:
+        prot, sugar = b, a
+    else:
+        return None
+    if sugar.name != "C1":
+        return None
+    return _make_site(prot, sugar)
+
+
+def _make_site(prot: _Atom, sugar: _Atom) -> dict:
+    return {
+        "prot_chain": prot.chain,
+        "prot_resid": prot.resnum,
+        "prot_icode": prot.icode,
+        "prot_resname": prot.resname,
+        "prot_atom": prot.name,
+        "sugar_chain": sugar.chain,
+        "sugar_resid": sugar.resnum,
+        "sugar_icode": sugar.icode,
+        "sugar_resname": sugar.resname,
+        "sugar_atom": sugar.name,
+    }
+
+
+def _site_signature(site: dict) -> tuple:
+    return (
+        site["prot_chain"],
+        site["prot_resid"],
+        site["prot_atom"],
+        site["sugar_chain"],
+        site["sugar_resid"],
+        site["sugar_atom"],
+    )
+
+
+def _make_glycan_link(a: _Atom, b: _Atom) -> dict:
+    return {
+        "from_chain": a.chain,
+        "from_resid": a.resnum,
+        "from_icode": a.icode,
+        "from_resname": a.resname,
+        "from_atom": a.name,
+        "to_chain": b.chain,
+        "to_resid": b.resnum,
+        "to_icode": b.icode,
+        "to_resname": b.resname,
+        "to_atom": b.name,
+    }
+
+
+def _link_signature(link: dict) -> tuple:
+    return (
+        link["from_chain"],
+        link["from_resid"],
+        link["from_atom"],
+        link["to_chain"],
+        link["to_resid"],
+        link["to_atom"],
+    )
+
+
+def _atom_position(atom_name: str) -> int | None:
+    """Substitution position encoded in a non-anomeric ring oxygen name
+    (``O3`` -> 3); ``None`` for the ring oxygen O5 and anomeric O1."""
+    if len(atom_name) < 2 or atom_name[0] != "O":
+        return None
+    rest = atom_name[1:]
+    if not rest[0].isdigit():
+        return None
+    try:
+        pos = int(rest[0])
+    except ValueError:
+        return None
+    if pos in (2, 3, 4, 6, 7, 8, 9):
+        return pos
+    return None
+
+
+def _format_atom_name(name: str) -> str:
+    """Format an atom name into the 4-character PDB atom-name field."""
+    if len(name) >= 4:
+        return name[:4]
+    return (" " + name).ljust(4)
+
+
+def _residue_sequential_index(pdb_path: str) -> dict[tuple[str, int], int]:
+    """Map (chain, resnum) -> 1-based sequential index in PDB file order."""
+    index: dict[tuple[str, int], int] = {}
+    seen_keys: list[tuple[str, int]] = []
+    with open(pdb_path, "r") as fh:
+        for line in fh:
+            rec = line[0:6].strip()
+            if rec not in ("ATOM", "HETATM"):
+                continue
+            try:
+                chain = line[21:22]
+                if not chain.strip():
+                    chain = " "
+                resnum = int(line[22:26])
+            except (IndexError, ValueError):
+                continue
+            key = (chain, resnum)
+            if key not in index:
+                index[key] = len(seen_keys) + 1
+                seen_keys.append(key)
+    return index

--- a/openmmdl/openmmdl_setup/openmmdlsetup.py
+++ b/openmmdl/openmmdl_setup/openmmdlsetup.py
@@ -18,6 +18,7 @@ from flask import (
 )
 from werkzeug.utils import secure_filename
 import datetime
+import os
 import shutil
 import sys
 from pathlib import Path
@@ -48,13 +49,70 @@ fixer = None
 scriptOutput = None
 simulationProcess = None
 
+
 def _normalize_resname(value, default):
     cleaned = "".join(ch for ch in (value or "").upper() if ch.isalnum())[:3]
     return cleaned if len(cleaned) == 3 else default
 
+
 def _resnames_are_unique(names):
     filtered = [name for name in names if name]
     return len(filtered) == len(set(filtered))
+
+
+def _read_uploaded_pdb_to_path(upload_key):
+    """Write an uploaded PDB to a temp file; return its path (or None)."""
+    if upload_key not in uploadedFiles:
+        return None
+    temp_handle, _orig_name = uploadedFiles[upload_key][0]
+    temp_handle.seek(0)
+    data = temp_handle.read()
+    if isinstance(data, bytes):
+        data = data.decode("utf-8", errors="replace")
+    fd, path = tempfile.mkstemp(suffix=".pdb")
+    try:
+        with os.fdopen(fd, "w") as fh:
+            fh.write(data)
+    except Exception:
+        try:
+            os.unlink(path)
+        except OSError:
+            pass
+        raise
+    return path
+
+
+def _run_glycoprotein_detection(upload_key="glycoprotFile"):
+    """Run glycan detection on the uploaded PDB; return a dict with glycans,
+    protein_links, glycan_glycan_links, rename_map (None if no upload)."""
+    from openmmdl.openmmdl_setup.glycoprotein import (
+        detect_glycans,
+        detect_glycosylation_sites,
+        detect_glycan_glycan_links,
+        determine_glycam_names,
+    )
+
+    pdb_path = _read_uploaded_pdb_to_path(upload_key)
+    if pdb_path is None:
+        return None
+    try:
+        glycans = detect_glycans(pdb_path)
+        sites = detect_glycosylation_sites(pdb_path)
+        links = detect_glycan_glycan_links(pdb_path)
+        rename_map = determine_glycam_names(glycans, sites, links)
+    finally:
+        try:
+            os.unlink(pdb_path)
+        except OSError:
+            pass
+
+    return {
+        "glycans": glycans,
+        "protein_links": sites,
+        "glycan_glycan_links": links,
+        "rename_map": rename_map,
+    }
+
 
 def saveUploadedFiles():
     uploadedFiles.clear()
@@ -128,16 +186,22 @@ def configureFiles():
         session["ligandMinimization"] = request.form.get("ligandMinimization", "")
         session["ligandSanitization"] = request.form.get("ligandSanitization", "")
         session["smallMoleculeMode"] = request.form.get("smallMoleculeMode", "none")
-        session["highThroughputSimulation"] = "True" if session["smallMoleculeMode"] == "library" else "False"
+        session["highThroughputSimulation"] = (
+            "True" if session["smallMoleculeMode"] == "library" else "False"
+        )
         session["sdfFile"] = uploadedFiles["sdfFile"][0][1] if "sdfFile" in uploadedFiles else ""
         session["companionFiles"] = [name for _, name in uploadedFiles.get("companionFile", [])]
         session["sdfResname"] = _normalize_resname(request.form.get("sdfResname", ""), "UNK")
         raw_companion_resnames = request.form.getlist("companionResname")
         session["companionResnames"] = [
-            _normalize_resname(raw_companion_resnames[i] if i < len(raw_companion_resnames) else "", f"L{i+1:02d}")
+            _normalize_resname(
+                raw_companion_resnames[i] if i < len(raw_companion_resnames) else "", f"L{i+1:02d}"
+            )
             for i in range(len(session["companionFiles"]))
         ]
-        all_resnames = ([session["sdfResname"]] if session["sdfFile"] else []) + session["companionResnames"]
+        all_resnames = ([session["sdfResname"]] if session["sdfFile"] else []) + session[
+            "companionResnames"
+        ]
         if not _resnames_are_unique(all_resnames):
             raise ValueError("Ligand topology codes must be unique.")
         configureDefaultOptions()
@@ -204,6 +268,11 @@ def setAmberOptions():
     session["other_rna_ff_input"] = request.form.get("other_rna_ff_input", "")
     session["carbo_ff"] = request.form.get("carbo_ff", "")
     session["other_carbo_ff_input"] = request.form.get("other_carbo_ff_input", "")
+    session["glycoprot_prot_ff"] = request.form.get("glycoprot_prot_ff", "")
+    session["glycoprot_other_prot_ff_input"] = request.form.get(
+        "glycoprot_other_prot_ff_input", ""
+    )
+    session["glycoprot_glycan_ff"] = request.form.get("glycoprot_glycan_ff", "leaprc.GLYCAM_06j-1")
 
     rcpType = session["rcpType"]
     if rcpType == "protRcp":
@@ -217,10 +286,24 @@ def setAmberOptions():
             return "# Upload an RNA receptor PDB file to generate the AMBER setup script.\n"
     elif rcpType == "carboRcp":
         if "carboFile" not in uploadedFiles:
-            return "# Upload a carbohydrate receptor PDB file to generate the AMBER setup script.\n"
+            return (
+                "# Upload a carbohydrate receptor PDB file to generate the AMBER setup script.\n"
+            )
+    elif rcpType == "glycoprotRcp":
+        if "glycoprotFile" not in uploadedFiles:
+            return "# Upload a glycoprotein PDB file to generate the AMBER setup script.\n"
+        # validate the upload; surface failures as a comment, not a 500
+        try:
+            _run_glycoprotein_detection()
+        except NotImplementedError as exc:
+            return f"# Glycoprotein detection failed: {exc}\n"
+        except Exception as exc:  # noqa: BLE001
+            return f"# Glycoprotein detection raised {type(exc).__name__}: {exc}\n"
 
     ######## Ligand ########
-    session["nmLig"] = "nmLig" in request.form  # store whether the nmLig checkbox is checked, e.g. True or False
+    session["nmLig"] = (
+        "nmLig" in request.form
+    )  # store whether the nmLig checkbox is checked, e.g. True or False
     session["spLig"] = "spLig" in request.form
     # save uploaded pdb or sdf file for ligand
     ## for normal ligand
@@ -230,7 +313,11 @@ def setAmberOptions():
 
     ## for special ligand
     if session["spLig"]:
-        if "spLigFile" not in uploadedFiles or "prepcFile" not in uploadedFiles or "frcmodFile" not in uploadedFiles:
+        if (
+            "spLigFile" not in uploadedFiles
+            or "prepcFile" not in uploadedFiles
+            or "frcmodFile" not in uploadedFiles
+        ):
             return "# Upload the special ligand PDB file plus matching PREPC and FRCMOD files to generate the AMBER setup script.\n"
 
     ######## Add Water/Membrane ########
@@ -272,6 +359,8 @@ def configureDefaultAmberOptions():
     session["dna_ff"] = "OL15"
     session["rna_ff"] = "OL3"
     session["carbo_ff"] = "GLYCAM_06j"
+    session["glycoprot_prot_ff"] = "leaprc.protein.ff14SB"
+    session["glycoprot_glycan_ff"] = "leaprc.GLYCAM_06j-1"
 
     # AddWaterMembrane
     session["addType"] = "addWater"
@@ -298,6 +387,7 @@ def createAmberBashScript():
         "dnaRcp": "dnaFile",
         "rnaRcp": "rnaFile",
         "carboRcp": "carboFile",
+        "glycoprotRcp": "glycoprotFile",
     }
     receptor_key = receptor_key_map.get(rcpType)
     if receptor_key is None or receptor_key not in uploadedFiles:
@@ -314,9 +404,10 @@ def createAmberBashScript():
         return "# Upload the special ligand PDB file plus matching PREPC and FRCMOD files to generate the AMBER setup script.\n"
 
     a_script = []
-    a_script.append("# This script was generated by OpenMMDL-Setup on %s.\n" % datetime.date.today())
     a_script.append(
-        """
+        "# This script was generated by OpenMMDL-Setup on %s.\n" % datetime.date.today()
+    )
+    a_script.append("""
         #       ,-----.    .-------.     .-''-.  ,---.   .--.,---.    ,---.,---.    ,---. ______       .---.      
         #     .'  .-,  '.  \  _(`)_ \  .'_ _   \ |    \  |  ||    \  /    ||    \  /    ||    _ `''.   | ,_|      
         #    / ,-.|  \ _ \ | (_ o._)| / ( ` )   '|  ,  \ |  ||  ,  \/  ,  ||  ,  \/  ,  || _ | ) _  \,-./  )      
@@ -328,13 +419,14 @@ def createAmberBashScript():
         #       '-----'    `---'        `'-..-'  '--'    '--''--'      '--''--'      '--''-----'`      `--------` 
                                                                                                       
                                                                                                       
-    """
-    )
+    """)
 
     a_script.append("#!/bin/bash\n")
 
     # Receptor
-    a_script.append("################################## Receptor ######################################")
+    a_script.append(
+        "################################## Receptor ######################################"
+    )
     rcpType = session["rcpType"]
     if rcpType == "protRcp":
         protFile = uploadedFiles["protFile"][0][1]
@@ -396,26 +488,134 @@ def createAmberBashScript():
             )
         a_script.append("\n")
 
-    a_script.append("## Clean the PDB file by pdb4amber")
-    a_script.append(("pdb4amber -i ${rcp_nm}.pdb -o ${rcp_nm}_amber.pdb"))
-    a_script.append(
-        """
+    elif rcpType == "glycoprotRcp":
+        glycoprotFile = uploadedFiles["glycoprotFile"][0][1]
+        glycoprotFile = glycoprotFile[:-4]
+        a_script.append(
+            "rcp_nm=%s # the file name of the glycoprotein without suffix `pdb`" % glycoprotFile
+        )
+
+        prot_ff = session.get("glycoprot_prot_ff", "leaprc.protein.ff14SB")
+        if prot_ff != "other_prot_ff":
+            a_script.append("prot_ff=%s" % prot_ff)
+        else:
+            a_script.append(
+                "prot_ff=%s  # See $AMBERHOME/dat/leap/cmd/ for supported force fields"
+                % session.get("glycoprot_other_prot_ff_input", "")
+            )
+
+        glycan_ff = session.get("glycoprot_glycan_ff", "leaprc.GLYCAM_06j-1")
+        a_script.append("glycan_ff=%s" % glycan_ff)
+
+        # alias rcp_ff to the protein FF; the glycan FF is sourced separately
+        a_script.append("rcp_ff=${prot_ff}")
+        a_script.append("\n")
+
+    if rcpType == "glycoprotRcp":
+        detection = _run_glycoprotein_detection()
+        if detection is None:
+            return "# Upload a glycoprotein PDB file to generate the AMBER setup script.\n"
+        rename_map = detection["rename_map"]
+        protein_links = detection["protein_links"]
+        glycan_links = detection["glycan_glycan_links"]
+        glycans = detection["glycans"]
+
+        a_script.append("## Detected glycans (PDB -> GLYCAM)")
+        for g in glycans:
+            code = rename_map.get((g["chain"], g["resnum"]), "???")
+            a_script.append(
+                "##   %s %s%d  ->  %s" % (g["resname"], g["chain"] or " ", g["resnum"], code)
+            )
+        a_script.append("## Glycosylation sites")
+        for s in protein_links:
+            a_script.append(
+                "##   %s %s%d.%s  --  %s %s%d.%s"
+                % (
+                    s["prot_resname"],
+                    s["prot_chain"] or " ",
+                    s["prot_resid"],
+                    s["prot_atom"],
+                    s["sugar_resname"],
+                    s["sugar_chain"] or " ",
+                    s["sugar_resid"],
+                    s["sugar_atom"],
+                )
+            )
+        a_script.append("## Glycan-glycan linkages")
+        for link in glycan_links:
+            a_script.append(
+                "##   %s %s%d.%s  --  %s %s%d.%s"
+                % (
+                    link["from_resname"],
+                    link["from_chain"] or " ",
+                    link["from_resid"],
+                    link["from_atom"],
+                    link["to_resname"],
+                    link["to_chain"] or " ",
+                    link["to_resid"],
+                    link["to_atom"],
+                )
+            )
+        a_script.append("\n## Rename glycan residues and atoms to GLYCAM conventions")
+        a_script.append("cat > _glyco_rename.py <<'PYEOF'")
+        a_script.append("from openmmdl.openmmdl_setup.glycoprotein import write_renamed_pdb")
+        a_script.append("rename_map = %r" % rename_map)
+        a_script.append(
+            "write_renamed_pdb('%s.pdb', '%s_renamed.pdb', rename_map)"
+            % (glycoprotFile, glycoprotFile)
+        )
+        a_script.append("PYEOF")
+        a_script.append("python3 _glyco_rename.py\n")
+
+        a_script.append("## Clean the renamed PDB by pdb4amber (no hydrogen rebuild)")
+        a_script.append("pdb4amber -i ${rcp_nm}_renamed.pdb -o ${rcp_nm}_amber.pdb --no-reduce")
+        # strip ACE/NME cap atoms tleap will rebuild from its templates
+        a_script.append(
+            """awk '! ($2 ~ "(CH3|HH31|HH32|HH33)" || $3 ~ "(CH3|HH31|HH32|HH33)" )' """
+            """${rcp_nm}_amber.pdb > ${rcp_nm}_amber_f.pdb"""
+        )
+        a_script.append("grep -v '^CONECT' ${rcp_nm}_amber_f.pdb > ${rcp_nm}_cnt_rmv.pdb\n")
+
+        a_script.append("## Emit explicit tleap bond statements for the glycosidic linkages")
+        a_script.append("cat > _glyco_bonds.py <<'PYEOF'")
+        a_script.append("from openmmdl.openmmdl_setup.glycoprotein import emit_bond_statements")
+        a_script.append("protein_links = %r" % protein_links)
+        a_script.append("glycan_links = %r" % glycan_links)
+        # read _renamed.pdb, not _amber.pdb: pdb4amber renumbers residues but
+        # keeps their order, so (chain, resid) keys only match the renamed file
+        a_script.append(
+            "for stmt in emit_bond_statements('%s_renamed.pdb', protein_links, glycan_links):"
+            % glycoprotFile
+        )
+        a_script.append("    print(stmt)")
+        a_script.append("PYEOF")
+        a_script.append("python3 _glyco_bonds.py > tleap.bonds.txt\n")
+    else:
+        a_script.append("## Clean the PDB file by pdb4amber")
+        a_script.append(("pdb4amber -i ${rcp_nm}.pdb -o ${rcp_nm}_amber.pdb"))
+        a_script.append(
+            """
 ## `tleap` requires that all residues and atoms have appropriate types to ensure compatibility with the specified force field.
 ## To avoid `tleap` failing, we delete non-essential atoms, such as hydrogens, but preserve important atoms like carbon and nitrogen within the caps residues.
 ## Don' worry about the missing atoms as tleap has the capability to reconstruct them automatically. """
-    )
-    a_script.append(
-        """awk '! ($2 ~ "(CH3|HH31|HH32|HH33)" || $3 ~ "(CH3|HH31|HH32|HH33)" )' ${rcp_nm}_amber.pdb > ${rcp_nm}_amber_f.pdb """
-    )
-    a_script.append("grep -v '^CONECT' ${rcp_nm}_amber_f.pdb > ${rcp_nm}_cnt_rmv.pdb\n")
+        )
+        a_script.append(
+            """awk '! ($2 ~ "(CH3|HH31|HH32|HH33)" || $3 ~ "(CH3|HH31|HH32|HH33)" )' ${rcp_nm}_amber.pdb > ${rcp_nm}_amber_f.pdb """
+        )
+        a_script.append("grep -v '^CONECT' ${rcp_nm}_amber_f.pdb > ${rcp_nm}_cnt_rmv.pdb\n")
 
     # Ligand
     if session["nmLig"] or session["spLig"]:
-        a_script.append("################################## Ligand ######################################")
+        a_script.append(
+            "################################## Ligand ######################################"
+        )
     if session["nmLig"]:
         a_script.append("# Normal Ligand that is compatible with GAFF force field")
         nmLigFile = uploadedFiles["nmLigFile"][0][1]
-        a_script.append("nmLigFile=%s # the file name of ligand without suffix `.pdb` or `.sdf`" % nmLigFile[:-4])
+        a_script.append(
+            "nmLigFile=%s # the file name of ligand without suffix `.pdb` or `.sdf`"
+            % nmLigFile[:-4]
+        )
         # depending on the uploaded file format,convert it to pdb or sdf file.
         if nmLigFile[-4:] == ".sdf":
             a_script.append(
@@ -427,7 +627,8 @@ def createAmberBashScript():
             )
 
         a_script.append(
-            "charge_method=%s # refers to the charge method that antechamber will adopt" % session["charge_method"]
+            "charge_method=%s # refers to the charge method that antechamber will adopt"
+            % session["charge_method"]
         )
         a_script.append(
             "charge_value=%s # Enter the net molecular charge of the ligand as integer (e.g. 1 or -2)"
@@ -442,18 +643,24 @@ def createAmberBashScript():
         a_script.append(
             "antechamber -fi pdb -fo prepc -i ${nmLigFile}_amber.pdb -o ${nmLigFile}.prepc -c ${charge_method} -at ${lig_ff} -nc ${charge_value} -pf y"
         )
-        a_script.append("## Write out the ligand with partial charge information via `antechamber`")
+        a_script.append(
+            "## Write out the ligand with partial charge information via `antechamber`"
+        )
         a_script.append(
             "antechamber -fi pdb -fo prepc -i ${nmLigFile}_amber.pdb -o ${nmLigFile}_pc.mol2 -c ${charge_method} -at ${lig_ff} -nc ${charge_value} -pf y"
         )
         a_script.append("parmchk2 -f prepc -i ${nmLigFile}.prepc -o ${nmLigFile}.frcmod\n")
         a_script.append("## Rename ligand pdb")
-        a_script.append("antechamber -i ${nmLigFile}.prepc -fi prepc -o rename_${nmLigFile}.pdb -fo pdb\n")
+        a_script.append(
+            "antechamber -i ${nmLigFile}.prepc -fi prepc -o rename_${nmLigFile}.pdb -fo pdb\n"
+        )
 
     if session["spLig"]:
         a_script.append("# Special Ligand that is incompatible with GAFF force field")
         spLigFile = uploadedFiles["spLigFile"][0][1]
-        a_script.append("spLigFile=%s # the file name of ligand without suffix `.pdb`" % spLigFile[:-4])
+        a_script.append(
+            "spLigFile=%s # the file name of ligand without suffix `.pdb`" % spLigFile[:-4]
+        )
         prepcFile = uploadedFiles["prepcFile"][0][1]
         prepcFile = prepcFile[:-6]
         a_script.append("prepc=%s # the file name without suffix `prepc`" % prepcFile)
@@ -470,9 +677,13 @@ def createAmberBashScript():
 
     # Combine all components to be modelled.
     if session["nmLig"] or session["spLig"]:
-        a_script.append("######################  Combine All Components to Be Modelled ####################")
+        a_script.append(
+            "######################  Combine All Components to Be Modelled ####################"
+        )
         a_script.append("cat > tleap.combine.in <<EOF\n")
         a_script.append("source ${rcp_ff}")
+        if rcpType == "glycoprotRcp":
+            a_script.append("source ${glycan_ff}")
         a_script.append("source leaprc.${lig_ff}")
         ## load the prepc and frcmod file for either normal or special ligand
         if session["nmLig"]:
@@ -483,6 +694,9 @@ def createAmberBashScript():
             a_script.append("loadamberparams ${frcmod}.frcmod\n")
         ## load both receptor and ligand pdb file
         a_script.append("rcp = loadpdb ${rcp_nm}_cnt_rmv.pdb")
+        if rcpType == "glycoprotRcp":
+            # declare the glycosidic bonds on `rcp` before combine
+            a_script.append("$(sed 's/system\\./rcp./g' tleap.bonds.txt)")
         if session["nmLig"] and session["spLig"]:
             a_script.append("nmLig = loadpdb rename_${nmLigFile}.pdb ")
             a_script.append("spLig = loadpdb ${spLigFile}_amber.pdb ")
@@ -502,14 +716,18 @@ def createAmberBashScript():
         a_script.append("grep -v '^CONECT' comp.pdb > comp_cnt_rmv.pdb\n")
 
     # Add Water/Membrane
-    a_script.append("################################ Add Water/Membrane ##############################")
+    a_script.append(
+        "################################ Add Water/Membrane ##############################"
+    )
 
     ## Box setting
     addType = session["addType"]
     if addType == "addWater":
         boxType = session["boxType"]
         if boxType == "cube":
-            a_script.append("boxType=solvatebox # `solvatebox`, a command in tleap, creates a cubic box ")
+            a_script.append(
+                "boxType=solvatebox # `solvatebox`, a command in tleap, creates a cubic box "
+            )
             a_script.append(
                 "dist=%s # the minimum distance between any atom originally present in solute and the edge of the periodic box."
                 % session["dist"]
@@ -542,7 +760,9 @@ def createAmberBashScript():
                 "lipid_tp=%s  # The command to check supported lipids: packmol-memgen --available_lipids"
                 % session["other_lipid_tp_input"]
             )
-            a_script.append(("lipid_ratio=%s # Set to 1 if only one lipid required" % session["lipid_ratio"]))
+            a_script.append(
+                ("lipid_ratio=%s # Set to 1 if only one lipid required" % session["lipid_ratio"])
+            )
 
         lipid_ff = session["lipid_ff"]
         if lipid_ff != "other_lipid_ff":
@@ -588,7 +808,9 @@ def createAmberBashScript():
             % session["other_water_ff_input"]
         )
         if addType == "addWater":
-            a_script.append("solvent=%sBOX  # set the water box" % session["other_water_ff_input"].upper())
+            a_script.append(
+                "solvent=%sBOX  # set the water box" % session["other_water_ff_input"].upper()
+            )
 
     ## Ion Setting
     pos_ion = session["pos_ion"]
@@ -620,9 +842,13 @@ def createAmberBashScript():
                 "packmol-memgen --pdb ${rcp_nm}_cnt_rmv.pdb --lipids ${lipid_tp} --ratio ${lipid_ratio} --preoriented --dist ${dist2Border} --dist_wat ${padDist} --salt --salt_c ${pos_ion} --saltcon ${ionConc} --nottrim --overwrite --notprotonate\n"
             )
             a_script.append("## Clean the complex pdb by `pdb4amber` for further `tleap` process")
-            a_script.append("pdb4amber -i bilayer_${rcp_nm}_cnt_rmv.pdb -o clean_bilayer_${rcp_nm}.pdb")
+            a_script.append(
+                "pdb4amber -i bilayer_${rcp_nm}_cnt_rmv.pdb -o clean_bilayer_${rcp_nm}.pdb"
+            )
             ## remove 'CONECT' line in the pdb file
-            a_script.append("grep -v '^CONECT' clean_bilayer_${rcp_nm}.pdb > clean_bilayer_${rcp_nm}_cnt_rmv.pdb")
+            a_script.append(
+                "grep -v '^CONECT' clean_bilayer_${rcp_nm}.pdb > clean_bilayer_${rcp_nm}_cnt_rmv.pdb"
+            )
             a_script.append("\n")
         if session["nmLig"] or session["spLig"]:
             a_script.append(
@@ -631,14 +857,20 @@ def createAmberBashScript():
             a_script.append("## Clean the complex pdb by `pdb4amber` for further `tleap` process")
             a_script.append("pdb4amber -i bilayer_comp.pdb -o clean_bilayer_comp.pdb")
             ## remove 'CONECT' line in the pdb file
-            a_script.append("grep -v '^CONECT' clean_bilayer_comp.pdb > clean_bilayer_comp_cnt_rmv.pdb")
+            a_script.append(
+                "grep -v '^CONECT' clean_bilayer_comp.pdb > clean_bilayer_comp_cnt_rmv.pdb"
+            )
             a_script.append("\n")
 
     # Generate the prmtop and frcmod file for the complex.
-    a_script.append("##################### Generate Prmtop and Frcmod File for the Complex ###################### ")
+    a_script.append(
+        "##################### Generate Prmtop and Frcmod File for the Complex ###################### "
+    )
     a_script.append("cat > tleap.in <<EOF\n")
     ## source the force field
     a_script.append("source ${rcp_ff}")
+    if rcpType == "glycoprotRcp":
+        a_script.append("source ${glycan_ff}")
     a_script.append("source leaprc.water.${water_ff}")
     if session["nmLig"] or session["spLig"]:
         a_script.append("source leaprc.${lig_ff}")
@@ -662,6 +894,9 @@ def createAmberBashScript():
             a_script.append("\nsystem = loadpdb clean_bilayer_${rcp_nm}_cnt_rmv.pdb\n")
         if session["nmLig"] or session["spLig"]:
             a_script.append("system = loadpdb clean_bilayer_comp_cnt_rmv.pdb\n")
+    ## glycosidic bonds (unless already declared in the combine step)
+    if rcpType == "glycoprotRcp" and not (session["nmLig"] or session["spLig"]):
+        a_script.append("$(cat tleap.bonds.txt)")
     ## add box
     if addType == "addWater":
         if boxType == "cube":
@@ -717,6 +952,7 @@ def getCurrentStructure():
     pdb = StringIO()
     PDBFile.writeFile(fixer.topology, fixer.positions, pdb)
     return pdb.getvalue()
+
 
 @app.route("/showSelectChains")
 def showSelectChainsPage():
@@ -855,9 +1091,9 @@ def showAddHydrogens():
     if unitCell is not None:
         unitCell = unitCell.value_in_unit(unit.nanometer)
     boundingBox = tuple(
-        (max((pos[i] for pos in fixer.positions)) - min((pos[i] for pos in fixer.positions))).value_in_unit(
-            unit.nanometer
-        )
+        (
+            max((pos[i] for pos in fixer.positions)) - min((pos[i] for pos in fixer.positions))
+        ).value_in_unit(unit.nanometer)
         for i in range(3)
     )
     return render_template("addHydrogens.html", unitCell=unitCell, boundingBox=boundingBox)
@@ -1002,7 +1238,11 @@ def downloadPackage():
             for i, mol in enumerate(supplier):
                 if mol is None:
                     continue
-                raw_name = mol.GetProp("_Name").strip() if mol.HasProp("_Name") and mol.GetProp("_Name").strip() else "ligand_%d" % i
+                raw_name = (
+                    mol.GetProp("_Name").strip()
+                    if mol.HasProp("_Name") and mol.GetProp("_Name").strip()
+                    else "ligand_%d" % i
+                )
                 mol_name = "".join(c if c.isalnum() or c in "_-" else "_" for c in raw_name)
                 folder = "openmmdl_simulation/%s" % mol_name
                 ligand_sdf_filename = "%s.sdf" % mol_name
@@ -1097,15 +1337,21 @@ def configureDefaultOptions():
     session["rmsd"] = "True"
     session["md_postprocessing"] = "True"
 
-def createScript(isInternal: bool = False, ligand_sdf_override: str | None = None, protein_path_override: str | None = None, companion_files_override: list[str] | None = None, companion_resnames_override: list[str] | None = None):
+
+def createScript(
+    isInternal: bool = False,
+    ligand_sdf_override: str | None = None,
+    protein_path_override: str | None = None,
+    companion_files_override: list[str] | None = None,
+    companion_resnames_override: list[str] | None = None,
+):
     script = []
 
     # If we are creating this script for internal use to run a simulation directly, add extra code at the top
     # to set the working directory and redirect stdout to the pipe.
 
     if isInternal:
-        script.append(
-            """
+        script.append("""
 import os
 import sys
 import time
@@ -1116,14 +1362,14 @@ class PipeOutput(object):
 
 sys.stdout = PipeOutput()
 sys.stderr = PipeOutput()
-os.chdir(outputDir)"""
-        )
+os.chdir(outputDir)""")
 
     # Header
 
-    script.append("# This script was generated by OpenMM-MDL Setup on %s.\n" % datetime.date.today())
     script.append(
-        """
+        "# This script was generated by OpenMM-MDL Setup on %s.\n" % datetime.date.today()
+    )
+    script.append("""
 #       ,-----.    .-------.     .-''-.  ,---.   .--.,---.    ,---.,---.    ,---. ______       .---.      
 #     .'  .-,  '.  \  _(`)_ \  .'_ _   \ |    \  |  ||    \  /    ||    \  /    ||    _ `''.   | ,_|      
 #    / ,-.|  \ _ \ | (_ o._)| / ( ` )   '|  ,  \ |  ||  ,  \/  ,  ||  ,  \/  ,  || _ | ) _  \,-./  )      
@@ -1135,8 +1381,7 @@ os.chdir(outputDir)"""
 #       '-----'    `---'        `'-..-'  '--'    '--''--'      '--''--'      '--''-----'`      `--------` 
                                                                                                       
                                                                                                       
-"""
-    )
+""")
     script.append(
         "from openmmdl.openmmdl_simulation.scripts.forcefield_water import ff_selection, water_forcefield_selection, water_model_selection, generate_forcefield, generate_transitional_forcefield"
     )
@@ -1154,7 +1399,9 @@ os.chdir(outputDir)"""
     script.append(
         "from simtk.openmm.app import PDBFile, Modeller, PDBReporter, StateDataReporter, DCDReporter, CheckpointReporter, AmberPrmtopFile, AmberInpcrdFile"
     )
-    script.append("from simtk.openmm import unit, Platform, MonteCarloBarostat, LangevinMiddleIntegrator")
+    script.append(
+        "from simtk.openmm import unit, Platform, MonteCarloBarostat, LangevinMiddleIntegrator"
+    )
     script.append("from openmm.openmm import XmlSerializer")
     script.append("from simtk.openmm import Vec3")
     script.append("import simtk.openmm as mm")
@@ -1179,27 +1426,46 @@ os.chdir(outputDir)"""
         )
         pdbType = session["pdbType"]
         if pdbType == "pdb":
-            pdb_path = protein_path_override if protein_path_override else uploadedFiles["file"][0][1]
+            pdb_path = (
+                protein_path_override if protein_path_override else uploadedFiles["file"][0][1]
+            )
             script.append('protein = "%s"' % pdb_path)
             if has_pdb_ligands:
                 ligand_paths = []
                 if session["sdfFile"] != "":
-                    ligand_paths.append(ligand_sdf_override if ligand_sdf_override else session["sdfFile"])
-                ligand_paths.extend(companion_files_override if companion_files_override is not None else session.get("companionFiles", []))
+                    ligand_paths.append(
+                        ligand_sdf_override if ligand_sdf_override else session["sdfFile"]
+                    )
+                ligand_paths.extend(
+                    companion_files_override
+                    if companion_files_override is not None
+                    else session.get("companionFiles", [])
+                )
                 ligand_names = []
                 if session["sdfFile"] != "":
                     ligand_names.append(session.get("sdfResname", "UNK"))
-                companion_resnames = companion_resnames_override if companion_resnames_override is not None else session.get("companionResnames", [])
+                companion_resnames = (
+                    companion_resnames_override
+                    if companion_resnames_override is not None
+                    else session.get("companionResnames", [])
+                )
                 expected_companion_count = len(ligand_paths) - len(ligand_names)
                 for i in range(expected_companion_count):
-                    ligand_names.append(companion_resnames[i] if i < len(companion_resnames) else f"L{i+1:02d}")
+                    ligand_names.append(
+                        companion_resnames[i] if i < len(companion_resnames) else f"L{i+1:02d}"
+                    )
                 script.append("ligands = %r" % ligand_paths)
                 script.append("ligand_names = %r" % ligand_names)
                 script.append("ligand = ligands[0]")
                 script.append("ligand_name = ligand_names[0]")
                 script.append("minimization = %s" % session["ligandMinimization"])
-                script.append("smallMoleculeForceField = '%s'" % session["smallMoleculeForceField"])
-                script.append("smallMoleculeForceFieldVersion = '%s'" % session["smallMoleculeForceFieldVersion"])
+                script.append(
+                    "smallMoleculeForceField = '%s'" % session["smallMoleculeForceField"]
+                )
+                script.append(
+                    "smallMoleculeForceFieldVersion = '%s'"
+                    % session["smallMoleculeForceFieldVersion"]
+                )
                 script.append("sanitization = %s" % session["ligandSanitization"])
             elif not has_pdb_ligands:
                 script.append("smallMoleculeForceField = None")
@@ -1231,7 +1497,9 @@ os.chdir(outputDir)"""
             # ligand related variables
             if session["nmLig"]:
                 nmLigFileName = uploadedFiles["nmLigFile"][0][1]  # e.g. '8QY.pdb'
-                nmLigName = extractLigName(nmLigFileName)  # e.g '8QY' or 'UNL' # resname in topology
+                nmLigName = extractLigName(
+                    nmLigFileName
+                )  # e.g '8QY' or 'UNL' # resname in topology
             else:
                 nmLigFileName = None
                 nmLigName = None
@@ -1248,7 +1516,9 @@ os.chdir(outputDir)"""
         script.append("inpcrd = AmberInpcrdFile(inpcrd_file)")
 
     if fileType == "pdb":
-        script.append("""\n############# Forcefield, Water and Membrane Model Selection ###################\n""")
+        script.append(
+            """\n############# Forcefield, Water and Membrane Model Selection ###################\n"""
+        )
         script.append("ff = '%s'" % session["forcefield"])
         if water != "None":
             script.append("water = '%s'" % water)
@@ -1273,7 +1543,9 @@ os.chdir(outputDir)"""
                 script.append("add_membrane = %s" % session["add_membrane"])
                 if session["water_padding"]:
                     script.append('Water_Box = "Buffer"')
-                    script.append("water_padding_distance = %s" % session["water_padding_distance"])
+                    script.append(
+                        "water_padding_distance = %s" % session["water_padding_distance"]
+                    )
                     script.append("water_boxShape = '%s'" % session["water_boxShape"])
                 else:
                     script.append('Water_Box = "Absolute"')
@@ -1353,10 +1625,13 @@ os.chdir(outputDir)"""
     if session["writeDCD"]:
         if session["restart_checkpoint"] == "yes":
             script.append(
-                "dcdReporter = DCDReporter('%s_%s', dcdInterval)" % (session["restart_step"], session["dcdFilename"])
+                "dcdReporter = DCDReporter('%s_%s', dcdInterval)"
+                % (session["restart_step"], session["dcdFilename"])
             )
         else:
-            script.append("dcdReporter = DCDReporter('%s', dcdInterval)" % (session["dcdFilename"]))
+            script.append(
+                "dcdReporter = DCDReporter('%s', dcdInterval)" % (session["dcdFilename"])
+            )
     if session["writeData"]:
         args = ", ".join("%s=True" % field for field in session["dataFields"])
         if session["restart_checkpoint"] == "yes":
@@ -1381,7 +1656,10 @@ os.chdir(outputDir)"""
                 % (session["dataInterval"], args)
             )
     if session["writeCheckpoint"]:
-        script.append("checkpointInterval = int(1000 * %s / %s)" % (session["checkpointInterval_ns"], session["dt"]))
+        script.append(
+            "checkpointInterval = int(1000 * %s / %s)"
+            % (session["checkpointInterval_ns"], session["dt"])
+        )
         if session["restart_checkpoint"] == "yes":
             script.append(
                 "checkpointReporter = CheckpointReporter('%s_%s', checkpointInterval)"
@@ -1397,7 +1675,8 @@ os.chdir(outputDir)"""
             )
         else:
             script.append(
-                "checkpointReporter = CheckpointReporter('%s', checkpointInterval)" % (session["checkpointFilename"])
+                "checkpointReporter = CheckpointReporter('%s', checkpointInterval)"
+                % (session["checkpointFilename"])
             )
             script.append(
                 "checkpointReporter10 = CheckpointReporter('10x_%s', checkpointInterval* 10)"
@@ -1412,8 +1691,7 @@ os.chdir(outputDir)"""
 
     if fileType == "pdb":
         if has_pdb_ligands:
-            script.append(
-                """
+            script.append("""
 print("Preparing MD Simulation with ligand(s)")
 protein_pdb = pdbfixer.PDBFixer(str(protein))
 prepared_ligands = [
@@ -1433,8 +1711,7 @@ for ligand_prepared, ligand_name in zip(prepared_ligands, ligand_names):
     complex_modeller.add(omm_ligand.topology, omm_ligand.positions)
 complex_topology = complex_modeller.topology
 complex_positions = complex_modeller.positions
-print("Complex topology has", complex_topology.getNumAtoms(), "atoms.")     """
-            )
+print("Complex topology has", complex_topology.getNumAtoms(), "atoms.")     """)
         elif not has_pdb_ligands:
             script.append(
                 """
@@ -1451,8 +1728,7 @@ if add_membrane:
         transitional_forcefield = generate_transitional_forcefield(protein_ff=forcefield_selected, solvent_ff=water_selected, add_membrane=add_membrane, smallMoleculeForceField=smallMoleculeForceField, smallMoleculeForceFieldVersion=smallMoleculeForceFieldVersion, rdkit_mol=None)     """
             )
         if not has_pdb_ligands:
-            script.append(
-                """
+            script.append("""
 forcefield = generate_forcefield(protein_ff=forcefield_selected, solvent_ff=water_selected, add_membrane=add_membrane, smallMoleculeForceField=smallMoleculeForceField, smallMoleculeForceFieldVersion=smallMoleculeForceFieldVersion, rdkit_mol=None)        
 modeller = app.Modeller(protein_pdb.topology, protein_pdb.positions)
 if add_membrane:
@@ -1464,11 +1740,9 @@ elif not add_membrane:
         modeller = water_absolute_solvent_builder(model_water, forcefield, water_box_x, water_box_y, water_box_z, protein_pdb, modeller, water_positive_ion, water_negative_ion, water_ionicstrength, protein)
 topology = modeller.topology
 positions = modeller.positions
-positions_for_equil = np.array(positions.value_in_unit(unit.nanometers)) * unit.nanometers """
-            )
+positions_for_equil = np.array(positions.value_in_unit(unit.nanometers)) * unit.nanometers """)
         elif has_pdb_ligands:
-            script.append(
-                """
+            script.append("""
 modeller = app.Modeller(complex_topology, complex_positions)
 if add_membrane:
     modeller = membrane_builder(ff, model_water, forcefield, transitional_forcefield, protein_pdb, modeller, membrane_lipid_type, membrane_padding, membrane_positive_ion, membrane_negative_ion, membrane_ionicstrength, protein)
@@ -1479,8 +1753,7 @@ elif not add_membrane:
         modeller = water_absolute_solvent_builder(model_water, forcefield, water_box_x, water_box_y, water_box_z, protein_pdb, modeller, water_positive_ion, water_negative_ion, water_ionicstrength, protein)
 topology = modeller.topology
 positions = modeller.positions  
-positions_for_equil = np.array(positions.value_in_unit(unit.nanometers)) * unit.nanometers """
-            )
+positions_for_equil = np.array(positions.value_in_unit(unit.nanometers)) * unit.nanometers """)
     elif fileType == "amber":
         script.append("topology = prmtop.topology")
         script.append("positions = inpcrd.positions")
@@ -1512,9 +1785,13 @@ positions_for_equil = np.array(positions.value_in_unit(unit.nanometers)) * unit.
                 hmrOptions,
             )
         )
-    script.append("write_ligand_with_partial_charges(topology, system, positions, ligand_name=globals().get('ligand_name'), ligand_names=globals().get('ligand_names'), ligand_files=globals().get('ligands'))")
+    script.append(
+        "write_ligand_with_partial_charges(topology, system, positions, ligand_name=globals().get('ligand_name'), ligand_names=globals().get('ligand_names'), ligand_files=globals().get('ligands'))"
+    )
     if ensemble == "npt":
-        script.append("system.addForce(MonteCarloBarostat(pressure, temperature, barostatInterval))")
+        script.append(
+            "system.addForce(MonteCarloBarostat(pressure, temperature, barostatInterval))"
+        )
     script.append("integrator = LangevinMiddleIntegrator(temperature, friction, dt)")
     if constraints != "none":
         script.append("integrator.setConstraintTolerance(constraintTolerance)")
@@ -1634,34 +1911,17 @@ stages = [
     },
 ]
             """)
-        script.append(
-            "run_gentle_equilibration("
-        )
-        script.append(
-            "    topology,"
-        )
-        script.append(
-            "    positions_for_equil,"
-        )
-        script.append(
-            "    system,"
-        )
-        script.append(
-            "    stages,"
-        )
-        script.append(
-            "    equil_output,"
-        )
-        script.append(
-            "    platform_name = '%s',"
-            % (session["platform"])
-        )
-        script.append(
-            ")"
-        )
+        script.append("run_gentle_equilibration(")
+        script.append("    topology,")
+        script.append("    positions_for_equil,")
+        script.append("    system,")
+        script.append("    stages,")
+        script.append("    equil_output,")
+        script.append("    platform_name = '%s'," % (session["platform"]))
+        script.append(")")
 
-        script.append("positions = PDBFile(equil_output).positions")        
-    
+        script.append("positions = PDBFile(equil_output).positions")
+
     if session["restart_checkpoint"] == "yes":
         script.append("simulation.loadCheckpoint('%s')" % session["checkpointFilename"])
 
@@ -1679,14 +1939,22 @@ stages = [
     script.append("simulation.context.setPositions(positions)")
     if session["restart_checkpoint"] == "yes":
         if fileType == "pdb":
-            script.append("simulation.reporters.append(PDBReporter(f'restart_output_{protein}', pdbInterval))")
+            script.append(
+                "simulation.reporters.append(PDBReporter(f'restart_output_{protein}', pdbInterval))"
+            )
         elif fileType == "amber":
-            script.append("simulation.reporters.append(PDBReporter(f'restart_output_{prmtop_file}', pdbInterval))")
+            script.append(
+                "simulation.reporters.append(PDBReporter(f'restart_output_{prmtop_file}', pdbInterval))"
+            )
     else:
         if fileType == "pdb":
-            script.append("simulation.reporters.append(PDBReporter(f'output_{protein}', pdbInterval))")
+            script.append(
+                "simulation.reporters.append(PDBReporter(f'output_{protein}', pdbInterval))"
+            )
         elif fileType == "amber":
-            script.append("simulation.reporters.append(PDBReporter(f'output_{prmtop_file[:-7]}.pdb', pdbInterval))")
+            script.append(
+                "simulation.reporters.append(PDBReporter(f'output_{prmtop_file[:-7]}.pdb', pdbInterval))"
+            )
     if session["writeDCD"]:
         script.append("simulation.reporters.append(dcdReporter)")
     if session["writeData"]:
@@ -1724,12 +1992,14 @@ stages = [
     script.append("close_reporters(simulation)")
     script.append("del simulation")
     script.append("gc.collect()")
-    
+
     # session[md_postprocessing]
     if session["md_postprocessing"] == "True":
         # mdtraj_conversion() and MDanalysis_conversion()
         if fileType == "pdb":
-            script.append("mdtraj_conversion(f'Equilibration_{protein}', '%s')" % session["mdtraj_output"])
+            script.append(
+                "mdtraj_conversion(f'Equilibration_{protein}', '%s')" % session["mdtraj_output"]
+            )
             if has_pdb_ligands:
                 if session["mdtraj_output"] != "mdtraj_gro_xtc":
                     script.append(
@@ -1809,20 +2079,27 @@ stages = [
     # post_md_file_movement()
     if fileType == "pdb":
         if has_pdb_ligands:
-            script.append("post_md_file_movement(protein, ligands=globals().get('ligands'), mda_selection='%s')" % session["mda_selection"])
+            script.append(
+                "post_md_file_movement(protein, ligands=globals().get('ligands'), mda_selection='%s')"
+                % session["mda_selection"]
+            )
         elif not has_pdb_ligands:
-            script.append("post_md_file_movement(protein, mda_selection='%s')" % session["mda_selection"])
+            script.append(
+                "post_md_file_movement(protein, mda_selection='%s')" % session["mda_selection"]
+            )
     elif fileType == "amber":
         if (
             session["has_files"] == "yes"
         ):  # In this case, no ligand file will be uploaded, thus not neccessary to assign value to argument `ligands`
             script.append(
-                "post_md_file_movement(protein_name=f'{prmtop_file[:-7]}.pdb', prmtop=prmtop_file, inpcrd=inpcrd_file, mda_selection='%s')" % session["mda_selection"]
+                "post_md_file_movement(protein_name=f'{prmtop_file[:-7]}.pdb', prmtop=prmtop_file, inpcrd=inpcrd_file, mda_selection='%s')"
+                % session["mda_selection"]
             )
         elif session["has_files"] == "no":
             if not session["nmLig"] and not session["spLig"]:
                 script.append(
-                    "post_md_file_movement(protein_name=f'{prmtop_file[:-7]}.pdb', prmtop=prmtop_file, inpcrd=inpcrd_file, mda_selection='%s')" % session["mda_selection"]
+                    "post_md_file_movement(protein_name=f'{prmtop_file[:-7]}.pdb', prmtop=prmtop_file, inpcrd=inpcrd_file, mda_selection='%s')"
+                    % session["mda_selection"]
                 )
             elif session["nmLig"] and not session["spLig"]:
                 script.append(
@@ -1835,10 +2112,7 @@ stages = [
                     % (nmLigFileName, spLigFileName, session["mda_selection"])
                 )
 
-    if (
-        session["md_postprocessing"] == "True"
-        and session.get("cleanup", "False") == "True"
-    ):
+    if session["md_postprocessing"] == "True" and session.get("cleanup", "False") == "True":
         script.append("cleanup_post_md()")
 
     # session[openmmdl_analysis]
@@ -1851,7 +2125,9 @@ stages = [
             top_ext = ".gro"
             traj_ext = ".xtc"
         if fileType == "pdb" and has_pdb_ligands:
-            script.append("analysis_special_flags = ''.join(f\" -s {name}\" for name in ligand_names[1:])")
+            script.append(
+                "analysis_special_flags = ''.join(f\" -s {name}\" for name in ligand_names[1:])"
+            )
         # session[analysis_selection] == 'analysis_all'
         if session["analysis_selection"] == "analysis_all":
             if fileType == "pdb":
@@ -2138,4 +2414,3 @@ def main(host="127.0.0.1", port=5000, open_browser=True):
 
 if __name__ == "__main__":
     main()
-

--- a/openmmdl/openmmdl_setup/templates/AmberOptions.html
+++ b/openmmdl/openmmdl_setup/templates/AmberOptions.html
@@ -158,7 +158,7 @@
             <label><input type="radio" name="rcpType" value='carboRcp' id="carboRcp" oninput="optionChanged()"> Carbohydrates
             </label>
           </div>
-          
+
           <div id="carboOptions">
             <div class="form-group">
               <div class="row">
@@ -166,7 +166,7 @@
                   <label for="carboFile"> Receptor File (.pdb) </label>
                   {{ fileinput('carboFile', accept='.pdb') }}
                 </div>
-          
+
                 <div class="col-lg-4">
                   <label for="carbo_ff"> Force Field</label>
                   <select name="carbo_ff" id="carbo_ff" class="form-control" onchange="optionChanged()">
@@ -175,13 +175,68 @@
                     <option value="other_carbo_ff">other</option>
                   </select>
                 </div>
-          
+
                 <!-- Add a container for the text field and hide it by default-->
                 <div class="col-lg-4" id="other_carbo_ff_container" style="display: none;">
                   <label for="other_carbo_ff_input" style="color:grey;">Other Force Field</label>
                   {{ textfield('other_carbo_ff_input', 'See the supported force fields in the original file at `$AMBERHOME/dat/leap/cmd/`')}}
                 </div>
-          
+
+              </div>
+            </div>
+          </div>
+
+          <!--Glycoproteins-->
+          <div class="form-group">
+            <label><input type="radio" name="rcpType" value='glycoprotRcp' id="glycoprotRcp" oninput="optionChanged()"> Glycoprotein
+            </label>
+          </div>
+
+          <div id="glycoprotOptions">
+            <div class="form-group" style="padding-left: 30px">
+              <div class="alert alert-info" style="margin-bottom: 10px">
+                OpenMMDL detects sugar residues by PDB name (NAG, NDG, BMA, MAN, FUC, FUL),
+                renames them and their atoms to GLYCAM conventions, and emits explicit
+                glycosidic-bond statements in the generated tleap script. The detected
+                sites are listed as <code>##</code> comments at the top of the script
+                preview on the right.
+              </div>
+            </div>
+            <div class="form-group">
+              <div class="row">
+                <div class="col-lg-6" style="padding-left: 30px">
+                  <label for="glycoprotFile">Glycoprotein File (.pdb)</label>
+                  {{ fileinput('glycoprotFile', accept='.pdb') }}
+                </div>
+
+                <div class="col-lg-4">
+                  <label for="glycoprot_prot_ff">Protein Force Field</label>
+                  <select name="glycoprot_prot_ff" id="glycoprot_prot_ff" class="form-control" onchange="optionChanged()">
+                    <option value="leaprc.protein.ff14SB" selected>ff14SB (recommended with GLYCAM_06j-1)</option>
+                    <option value="leaprc.protein.ff19SB">ff19SB</option>
+                    <option value="leaprc.ff99SB">ff99SB</option>
+                    <option value="leaprc.protein.ff14SBonlysc">ff14SBonlysc</option>
+                    <option value="other_glycoprot_prot_ff">other</option>
+                  </select>
+                </div>
+
+                <div class="col-lg-4" id="other_glycoprot_prot_ff_container" style="display: none;">
+                  <label for="glycoprot_other_prot_ff_input" style="color:grey;">Other Protein Force Field</label>
+                  {{ textfield('glycoprot_other_prot_ff_input', 'See the supported force fields in the original file at `$AMBERHOME/dat/leap/cmd/`')}}
+                </div>
+              </div>
+            </div>
+
+            <div class="form-group">
+              <div class="row">
+                <div class="col-lg-6" style="padding-left: 30px">
+                  <label for="glycoprot_glycan_ff">Glycan Force Field</label>
+                  <select name="glycoprot_glycan_ff" id="glycoprot_glycan_ff" class="form-control" onchange="optionChanged()">
+                    <option value="leaprc.GLYCAM_06j-1" selected>GLYCAM_06j-1 (ff14SB / ff19SB compatible)</option>
+                    <option value="leaprc.GLYCAM_06j">GLYCAM_06j</option>
+                    <option value="leaprc.GLYCAM_06EPb">GLYCAM_06EPb</option>
+                  </select>
+                </div>
               </div>
             </div>
           </div>
@@ -570,6 +625,8 @@ function optionChanged() {
   document.getElementById('rnaOptions').hidden = !rnaRcp;
   carboRcp = document.getElementById("carboRcp").checked;
   document.getElementById('carboOptions').hidden = !carboRcp;
+  glycoprotRcp = document.getElementById("glycoprotRcp").checked;
+  document.getElementById('glycoprotOptions').hidden = !glycoprotRcp;
 
   protFile = document.getElementById("protFile").files;
   document.getElementById("protFile_label").textContent = (protFile.length == 0 ? "" : protFile[0].name);
@@ -579,6 +636,8 @@ function optionChanged() {
   document.getElementById("rnaFile_label").textContent = (rnaFile.length == 0 ? "" : rnaFile[0].name);
   carboFile = document.getElementById("carboFile").files;
   document.getElementById("carboFile_label").textContent = (carboFile.length == 0 ? "" : carboFile[0].name);
+  glycoprotFile = document.getElementById("glycoprotFile").files;
+  document.getElementById("glycoprotFile_label").textContent = (glycoprotFile.length == 0 ? "" : glycoprotFile[0].name);
 
   //for tab 'Add Water/Membrane'
   addWater = document.getElementById("addWater").checked;
@@ -620,6 +679,7 @@ function optionChanged() {
     { id: 'dna_ff', containerId: 'other_dna_ff_container' },
     { id: 'rna_ff', containerId: 'other_rna_ff_container' },
     { id: 'carbo_ff', containerId: 'other_carbo_ff_container' },
+    { id: 'glycoprot_prot_ff', containerId: 'other_glycoprot_prot_ff_container' },
 
     { id: 'lipid_tp', containerId: 'other_lipid_tp_container' },
     { id: 'lipid_tp', containerId: 'lipid_ratio' },

--- a/openmmdl/openmmdl_simulation/scripts/post_md_conversions.py
+++ b/openmmdl/openmmdl_simulation/scripts/post_md_conversions.py
@@ -8,6 +8,7 @@ from MDAnalysis.analysis import align
 from MDAnalysis import transformations as trans
 from MDAnalysis.lib import distances
 
+
 def _close_mda_objects(*objs):
     for obj in objs:
         if obj is None:
@@ -18,6 +19,36 @@ def _close_mda_objects(*objs):
                 traj.close()
             except Exception:
                 pass
+
+
+def residues_bonded_to_protein(universe):
+    """Return residues covalently bonded to protein atoms but not themselves
+    protein (i.e. N-/O-glycans). Empty AtomGroup if no protein or no bonds."""
+    try:
+        prot = universe.select_atoms("protein")
+    except Exception:
+        return universe.atoms[0:0]
+    if prot.n_atoms == 0:
+        return universe.atoms[0:0]
+    try:
+        bonds = prot.bonds
+    except Exception:
+        return universe.atoms[0:0]
+
+    protein_atom_ix = set(prot.indices.tolist())
+    other_atom_ix = []
+    for bond in bonds:
+        a, b = bond.atoms[0], bond.atoms[1]
+        a_in = a.index in protein_atom_ix
+        b_in = b.index in protein_atom_ix
+        if a_in and not b_in:
+            other_atom_ix.append(b.index)
+        elif b_in and not a_in:
+            other_atom_ix.append(a.index)
+    if not other_atom_ix:
+        return universe.atoms[0:0]
+    return universe.atoms[other_atom_ix].residues.atoms
+
 
 def mdtraj_conversion(pdb_file, mdtraj_output):
     """
@@ -112,6 +143,9 @@ def MDanalysis_conversion(
         # Optional keyword; if unsupported, returns empty.
         return _safe_select(u, "lipid")
 
+    def _glycan_group(u):
+        return residues_bonded_to_protein(u)
+
     def _has_pbc(ts):
         dims = getattr(ts, "dimensions", None)
         if dims is None or len(dims) < 3:
@@ -199,16 +233,22 @@ def MDanalysis_conversion(
         prot = _safe_select(u, "protein")
         lig = _ligand_group(u)
         lip = _lipid_group(u)
+        glycan = _glycan_group(u)
 
-        # Anchor for centering: protein + ligand + lipids (if present)
+        # Anchor for centering: protein + ligand + lipids + glycans (if present)
         anchor = prot if prot.n_atoms else u.atoms
         if lig.n_atoms:
             anchor = anchor + lig
         if lip.n_atoms:
             anchor = anchor + lip
+        if glycan.n_atoms:
+            anchor = anchor + glycan
 
         protein = prot
         non_protein = _safe_select(u, "not protein")
+        # exclude glycans from the per-residue wrap so they stay with the protein
+        if glycan.n_atoms:
+            non_protein = non_protein - glycan
 
         transforms = []
 
@@ -228,12 +268,19 @@ def MDanalysis_conversion(
         if lip.n_atoms and protein.n_atoms:
             transforms.append(reimage_residues_to_reference(lip, protein))
 
+        # Keep covalently-attached glycans in the same image as the protein
+        if glycan.n_atoms and protein.n_atoms:
+            if _can_unwrap(glycan):
+                transforms.append(trans.unwrap(glycan))
+            transforms.append(reimage_to_reference(glycan, protein))
+
         # Center then wrap: protein by segments; everything else by residues
         transforms.append(trans.center_in_box(anchor, center="mass", wrap=False))
 
         if protein.n_atoms:
             transforms.append(trans.wrap(protein, compound="segments"))
-        transforms.append(trans.wrap(non_protein, compound="residues"))
+        if non_protein.n_atoms:
+            transforms.append(trans.wrap(non_protein, compound="residues"))
 
         u.trajectory.add_transformations(*transforms)
 
@@ -250,9 +297,12 @@ def MDanalysis_conversion(
         prot2 = _safe_select(u2, "protein")
         lig2 = _ligand_group(u2)
         lip2 = _lipid_group(u2)
+        glycan2 = _glycan_group(u2)
 
         protein2 = prot2
         non_protein2 = _safe_select(u2, "not protein")
+        if glycan2.n_atoms:
+            non_protein2 = non_protein2 - glycan2
 
         transforms = []
 
@@ -265,9 +315,13 @@ def MDanalysis_conversion(
         if lip2.n_atoms and protein2.n_atoms:
             transforms.append(reimage_residues_to_reference(lip2, protein2))
 
+        if glycan2.n_atoms and protein2.n_atoms:
+            transforms.append(reimage_to_reference(glycan2, protein2))
+
         if protein2.n_atoms:
             transforms.append(trans.wrap(protein2, compound="segments"))
-        transforms.append(trans.wrap(non_protein2, compound="residues"))
+        if non_protein2.n_atoms:
+            transforms.append(trans.wrap(non_protein2, compound="residues"))
 
         u2.trajectory.add_transformations(*transforms)
 

--- a/openmmdl/tests/openmmdl_setup/test_glycoprotein.py
+++ b/openmmdl/tests/openmmdl_setup/test_glycoprotein.py
@@ -1,0 +1,279 @@
+"""Unit tests for openmmdl.openmmdl_setup.glycoprotein."""
+
+import os
+import tempfile
+import textwrap
+
+import pytest
+
+from openmmdl.openmmdl_setup.glycoprotein import (
+    LINKAGE_CODE,
+    PDB_SUGAR_RESNAMES,
+    SUGAR_ATOM_RENAME,
+    SUGAR_TABLE,
+    detect_glycan_glycan_links,
+    detect_glycans,
+    detect_glycosylation_sites,
+    determine_glycam_names,
+    emit_bond_statements,
+    write_renamed_pdb,
+)
+
+
+def _write_pdb(content):
+    fd, path = tempfile.mkstemp(suffix=".pdb")
+    with os.fdopen(fd, "w") as fh:
+        fh.write(content)
+    return path
+
+
+@pytest.fixture
+def empty_pdb():
+    path = _write_pdb("END\n")
+    yield path
+    os.unlink(path)
+
+
+@pytest.fixture
+def asn_nag_pdb():
+    """Single N-glycan: Asn 250 -- NAG 600 (single sugar, terminal)."""
+    pdb = textwrap.dedent("""\
+        ATOM      1  N   ASN A 250      10.000  10.000  10.000  1.00  0.00           N
+        ATOM      2  CA  ASN A 250      11.000  10.000  10.000  1.00  0.00           C
+        ATOM      3  CB  ASN A 250      12.000  10.000  10.000  1.00  0.00           C
+        ATOM      4  CG  ASN A 250      13.000  10.000  10.000  1.00  0.00           C
+        ATOM      5  OD1 ASN A 250      13.500  10.866  10.000  1.00  0.00           O
+        ATOM      6  ND2 ASN A 250      13.500   9.134  10.000  1.00  0.00           N
+        HETATM    7  C1  NAG A 600      14.800   8.700  10.000  1.00  0.00           C
+        HETATM    8  C2  NAG A 600      15.300   7.700  10.000  1.00  0.00           C
+        HETATM    9  O3  NAG A 600      16.300   7.000  10.000  1.00  0.00           O
+        HETATM   10  O4  NAG A 600      15.800   9.700  10.000  1.00  0.00           O
+        HETATM   11  O6  NAG A 600      14.300  10.700  10.000  1.00  0.00           O
+        HETATM   12  N2  NAG A 600      15.500   6.800  10.000  1.00  0.00           N
+        HETATM   13  C7  NAG A 600      16.500   6.000  10.000  1.00  0.00           C
+        CONECT    6    7
+        END
+        """)
+    path = _write_pdb(pdb)
+    yield path
+    os.unlink(path)
+
+
+@pytest.fixture
+def n_glycan_core_pdb():
+    """Full N-glycan core: Asn -- NAG_1 -- NAG_2 -- BMA -- (MAN_a, MAN_b),
+    with a core fucose alpha-1,6 on NAG_1.
+    """
+    pdb = textwrap.dedent("""\
+        ATOM      1  N   ASN A 250      10.000  10.000  10.000  1.00  0.00           N
+        ATOM      2  CA  ASN A 250      11.000  10.000  10.000  1.00  0.00           C
+        ATOM      3  CB  ASN A 250      12.000  10.000  10.000  1.00  0.00           C
+        ATOM      4  CG  ASN A 250      13.000  10.000  10.000  1.00  0.00           C
+        ATOM      5  OD1 ASN A 250      13.500  10.866  10.000  1.00  0.00           O
+        ATOM      6  ND2 ASN A 250      13.500   9.134  10.000  1.00  0.00           N
+        HETATM    7  C1  NAG A 600      14.800   8.700  10.000  1.00  0.00           C
+        HETATM    8  O4  NAG A 600      15.800   9.700  10.000  1.00  0.00           O
+        HETATM   11  O6  NAG A 600      14.300  10.700  10.000  1.00  0.00           O
+        HETATM   16  C1  NAG A 601      17.250   9.700  10.000  1.00  0.00           C
+        HETATM   17  O4  NAG A 601      18.250   9.700  10.000  1.00  0.00           O
+        HETATM   18  C1  BMA A 602      19.500   9.700  10.000  1.00  0.00           C
+        HETATM   19  O3  BMA A 602      20.500   9.700  10.000  1.00  0.00           O
+        HETATM   20  O6  BMA A 602      19.500  11.000  10.000  1.00  0.00           O
+        HETATM   21  C1  MAN A 603      21.700   9.700  10.000  1.00  0.00           C
+        HETATM   22  C1  MAN A 604      19.500  12.200  10.000  1.00  0.00           C
+        HETATM   23  C1  FUC A 605      15.500  11.700  10.000  1.00  0.00           C
+        CONECT    6    7
+        CONECT    8   16
+        CONECT   17   18
+        CONECT   19   21
+        CONECT   20   22
+        CONECT   11   23
+        END
+        """)
+    path = _write_pdb(pdb)
+    yield path
+    os.unlink(path)
+
+
+def test_sugar_table_anomer_letters_are_a_or_b():
+    for resname, (_letter, anomer) in SUGAR_TABLE.items():
+        assert anomer in ("A", "B"), f"{resname} has non-A/B anomer letter {anomer!r}"
+
+
+def test_pdb_sugar_resnames_match_table_keys():
+    assert PDB_SUGAR_RESNAMES == frozenset(SUGAR_TABLE.keys())
+
+
+def test_linkage_codes_for_n_glycan_core():
+    assert LINKAGE_CODE[()] == "0"
+    assert LINKAGE_CODE[(4,)] == "4"
+    assert LINKAGE_CODE[(3,)] == "3"
+    assert LINKAGE_CODE[(6,)] == "6"
+    assert LINKAGE_CODE[(3, 6)] == "V"
+    assert LINKAGE_CODE[(4, 6)] == "U"
+
+
+def test_nag_atom_rename_table_remaps_acetyl_group():
+    rename = SUGAR_ATOM_RENAME["NAG"]
+    assert rename["C7"] == "C2N"
+    assert rename["O7"] == "O2N"
+    assert rename["C8"] == "CME"
+    assert rename["HN2"] == "H2N"
+
+
+def test_mannose_atom_rename_table_only_remaps_hydroxyl_hs():
+    rename = SUGAR_ATOM_RENAME["MAN"]
+    assert rename["HO3"] == "H3O"
+    assert rename["HO4"] == "H4O"
+    assert rename["HO6"] == "H6O"
+    assert "C7" not in rename
+    assert "C1" not in rename
+
+
+def test_detect_glycans_empty_pdb(empty_pdb):
+    assert detect_glycans(empty_pdb) == []
+
+
+def test_detect_glycans_single_residue(asn_nag_pdb):
+    glycans = detect_glycans(asn_nag_pdb)
+    assert len(glycans) == 1
+    g = glycans[0]
+    assert g["resname"] == "NAG"
+    assert g["chain"] == "A"
+    assert g["resnum"] == 600
+    assert g["atoms"][0] == ("C1", 7)
+
+
+def test_detect_glycans_n_glycan_core(n_glycan_core_pdb):
+    glycans = detect_glycans(n_glycan_core_pdb)
+    resnames = [g["resname"] for g in glycans]
+    assert resnames == ["NAG", "NAG", "BMA", "MAN", "MAN", "FUC"]
+
+
+def test_detect_glycosylation_sites_conect_based(asn_nag_pdb):
+    sites = detect_glycosylation_sites(asn_nag_pdb)
+    assert len(sites) == 1
+    s = sites[0]
+    assert s["prot_resname"] == "ASN"
+    assert s["prot_atom"] == "ND2"
+    assert s["prot_resid"] == 250
+    assert s["sugar_resname"] == "NAG"
+    assert s["sugar_atom"] == "C1"
+    assert s["sugar_resid"] == 600
+
+
+def test_detect_glycosylation_sites_distance_fallback():
+    # no CONECT records -> distance fallback
+    pdb_no_conect = textwrap.dedent("""\
+        ATOM      6  ND2 ASN A 250      13.500   9.134  10.000  1.00  0.00           N
+        HETATM    7  C1  NAG A 600      14.800   8.700  10.000  1.00  0.00           C
+        END
+        """)
+    path = _write_pdb(pdb_no_conect)
+    try:
+        sites = detect_glycosylation_sites(path)
+        assert len(sites) == 1
+        assert sites[0]["prot_resname"] == "ASN"
+        assert sites[0]["sugar_resname"] == "NAG"
+    finally:
+        os.unlink(path)
+
+
+def test_detect_glycosylation_sites_returns_empty_when_no_acceptor():
+    pdb = textwrap.dedent("""\
+        HETATM    1  C1  NAG A 600      14.800   8.700  10.000  1.00  0.00           C
+        END
+        """)
+    path = _write_pdb(pdb)
+    try:
+        assert detect_glycosylation_sites(path) == []
+    finally:
+        os.unlink(path)
+
+
+def test_detect_glycan_glycan_links_branched_core(n_glycan_core_pdb):
+    links = detect_glycan_glycan_links(n_glycan_core_pdb)
+    assert len(links) == 5
+    pairs = {
+        (
+            link["from_resname"] + str(link["from_resid"]),
+            link["from_atom"],
+            link["to_resname"] + str(link["to_resid"]),
+            link["to_atom"],
+        )
+        for link in links
+    }
+    assert ("NAG600", "O4", "NAG601", "C1") in pairs
+    assert ("NAG600", "O6", "FUC605", "C1") in pairs
+    assert ("BMA602", "O3", "MAN603", "C1") in pairs
+    assert ("BMA602", "O6", "MAN604", "C1") in pairs
+
+
+def test_determine_glycam_names_terminal(asn_nag_pdb):
+    glycans = detect_glycans(asn_nag_pdb)
+    sites = detect_glycosylation_sites(asn_nag_pdb)
+    links = detect_glycan_glycan_links(asn_nag_pdb)
+    names = determine_glycam_names(glycans, sites, links)
+    assert names == {("A", 600): "0YB", ("A", 250): "NLN"}
+
+
+def test_determine_glycam_names_n_glycan_core(n_glycan_core_pdb):
+    glycans = detect_glycans(n_glycan_core_pdb)
+    sites = detect_glycosylation_sites(n_glycan_core_pdb)
+    links = detect_glycan_glycan_links(n_glycan_core_pdb)
+    names = determine_glycam_names(glycans, sites, links)
+    assert names[("A", 600)] == "UYB"  # NAG_1: O4 + O6 substituted
+    assert names[("A", 601)] == "4YB"  # NAG_2: O4 substituted
+    assert names[("A", 602)] == "VMB"  # BMA: O3 + O6 substituted
+    assert names[("A", 603)] == "0MA"
+    assert names[("A", 604)] == "0MA"
+    assert names[("A", 605)] == "0fA"
+
+
+def test_determine_glycam_names_unsupported_sugar_raises():
+    glycans = [{"chain": "A", "resnum": 1, "icode": " ", "resname": "SIA", "atoms": []}]
+    with pytest.raises(NotImplementedError) as exc:
+        determine_glycam_names(glycans, [], [])
+    assert "SIA" in str(exc.value)
+
+
+def test_write_renamed_pdb_residue_and_atom_renames(asn_nag_pdb):
+    out_fd, out_path = tempfile.mkstemp(suffix=".pdb")
+    os.close(out_fd)
+    try:
+        write_renamed_pdb(asn_nag_pdb, out_path, {("A", 600): "0YB"})
+        with open(out_path) as f:
+            text = f.read()
+        assert "0YB" in text
+        assert " NAG " not in text
+        assert " C2N " in text
+        assert " ASN " in text
+    finally:
+        os.unlink(out_path)
+
+
+def test_write_renamed_pdb_preserves_conect(asn_nag_pdb):
+    out_fd, out_path = tempfile.mkstemp(suffix=".pdb")
+    os.close(out_fd)
+    try:
+        write_renamed_pdb(asn_nag_pdb, out_path, {("A", 600): "0YB"})
+        with open(out_path) as f:
+            lines = f.readlines()
+        conect_lines = [l for l in lines if l.startswith("CONECT")]
+        assert len(conect_lines) == 1
+        assert "    6    7" in conect_lines[0]
+    finally:
+        os.unlink(out_path)
+
+
+def test_emit_bond_statements_uses_sequential_indices(asn_nag_pdb):
+    sites = detect_glycosylation_sites(asn_nag_pdb)
+    stmts = emit_bond_statements(asn_nag_pdb, sites, [])
+    assert stmts == ["bond system.1.ND2 system.2.C1"]
+
+
+def test_emit_bond_statements_n_glycan_core_count(n_glycan_core_pdb):
+    sites = detect_glycosylation_sites(n_glycan_core_pdb)
+    links = detect_glycan_glycan_links(n_glycan_core_pdb)
+    stmts = emit_bond_statements(n_glycan_core_pdb, sites, links)
+    assert len(stmts) == 6  # 1 protein-glycan + 5 glycan-glycan

--- a/openmmdl/tests/openmmdl_setup/test_glycoprotein_integration.py
+++ b/openmmdl/tests/openmmdl_setup/test_glycoprotein_integration.py
@@ -1,0 +1,192 @@
+"""End-to-end test: glycoprotein PDB upload -> createAmberBashScript output.
+
+Asserts the generated bash script contains the right tleap-mode pieces
+(both protein and glycan force fields sourced, rename + bond runtime
+helpers emitted, awk filter skipped, etc.). Does not actually execute
+tleap.
+"""
+
+import tempfile
+import textwrap
+
+import pytest
+
+# skip the module if the heavy deps (rdkit/openmm) aren't installed
+pytest.importorskip("openmm")
+pytest.importorskip("rdkit")
+pytest.importorskip("flask")
+
+from openmmdl.openmmdl_setup import openmmdlsetup as M  # noqa: E402
+
+_TINY_GLYCOPROTEIN_PDB = textwrap.dedent("""\
+    ATOM      1  N   ASN A 250      10.000  10.000  10.000  1.00  0.00           N
+    ATOM      2  CA  ASN A 250      11.000  10.000  10.000  1.00  0.00           C
+    ATOM      3  CB  ASN A 250      12.000  10.000  10.000  1.00  0.00           C
+    ATOM      4  CG  ASN A 250      13.000  10.000  10.000  1.00  0.00           C
+    ATOM      5  OD1 ASN A 250      13.500  10.866  10.000  1.00  0.00           O
+    ATOM      6  ND2 ASN A 250      13.500   9.134  10.000  1.00  0.00           N
+    HETATM    7  C1  NAG A 600      14.800   8.700  10.000  1.00  0.00           C
+    HETATM    8  O4  NAG A 600      15.800   9.700  10.000  1.00  0.00           O
+    HETATM    9  N2  NAG A 600      15.500   6.800  10.000  1.00  0.00           N
+    CONECT    6    7
+    END
+    """)
+
+
+class _FakeSession(dict):
+    def get(self, k, d=None):
+        return super().get(k, d)
+
+
+@pytest.fixture
+def glycoprot_session(monkeypatch):
+    """Set up uploadedFiles + session as if the user had POSTed the form."""
+    temp = tempfile.TemporaryFile()
+    temp.write(_TINY_GLYCOPROTEIN_PDB.encode())
+    temp.seek(0)
+    monkeypatch.setattr(M, "uploadedFiles", {"glycoprotFile": [(temp, "tinyglyco.pdb")]})
+    fake_session = _FakeSession(
+        {
+            "rcpType": "glycoprotRcp",
+            "glycoprot_prot_ff": "leaprc.protein.ff14SB",
+            "glycoprot_glycan_ff": "leaprc.GLYCAM_06j-1",
+            "nmLig": False,
+            "spLig": False,
+            "addType": "addWater",
+            "boxType": "cube",
+            "dist": "10",
+            "water_ff": "tip3p",
+            "pos_ion": "Na+",
+            "neg_ion": "Cl-",
+            "ionConc": "0.15",
+        }
+    )
+    monkeypatch.setattr(M, "session", fake_session)
+    yield fake_session
+
+
+def test_glycoprotein_script_sources_both_force_fields(glycoprot_session):
+    script = M.createAmberBashScript()
+    assert "source ${rcp_ff}" in script
+    assert "source ${glycan_ff}" in script
+    assert "prot_ff=leaprc.protein.ff14SB" in script
+    assert "glycan_ff=leaprc.GLYCAM_06j-1" in script
+
+
+def test_glycoprotein_script_uses_awk_cap_filter(glycoprot_session):
+    # the awk filter strips ACE/NME cap atoms that tleap rebuilds from templates
+    script = M.createAmberBashScript()
+    assert "awk" in script
+    assert "CH3|HH31|HH32|HH33" in script
+
+
+def test_glycoprotein_script_uses_pdb4amber_no_reduce(glycoprot_session):
+    script = M.createAmberBashScript()
+    assert "pdb4amber -i ${rcp_nm}_renamed.pdb" in script
+    assert "--no-reduce" in script
+
+
+def test_glycoprotein_script_emits_rename_and_bond_helpers(glycoprot_session):
+    script = M.createAmberBashScript()
+    assert "_glyco_rename.py" in script
+    assert "_glyco_bonds.py" in script
+    assert "tleap.bonds.txt" in script
+    assert "write_renamed_pdb" in script
+    assert "emit_bond_statements" in script
+
+
+def test_glycoprotein_script_inlines_renamed_residues(glycoprot_session):
+    script = M.createAmberBashScript()
+    assert "'0YB'" in script
+    assert "rename_map = {" in script
+
+
+def test_glycoprotein_script_inlines_protein_links(glycoprot_session):
+    script = M.createAmberBashScript()
+    assert "'ND2'" in script
+    assert "'C1'" in script
+
+
+def test_glycoprotein_script_inject_bonds_after_loadpdb(glycoprot_session):
+    script = M.createAmberBashScript()
+    # Without a ligand, bonds are inlined into the main tleap.in heredoc.
+    assert "$(cat tleap.bonds.txt)" in script
+    loadpdb_idx = script.find("system = loadpdb ${rcp_nm}_cnt_rmv.pdb")
+    bond_idx = script.find("$(cat tleap.bonds.txt)")
+    assert loadpdb_idx != -1 and bond_idx != -1
+    assert bond_idx > loadpdb_idx, "bonds must come after loadpdb"
+
+
+def test_protein_rcp_script_is_unchanged_no_glycoprot_leakage(monkeypatch):
+    temp = tempfile.TemporaryFile()
+    temp.write(b"ATOM      1  N   ASN A   1      10 10 10  1.00 0.00\nEND\n")
+    temp.seek(0)
+    monkeypatch.setattr(M, "uploadedFiles", {"protFile": [(temp, "myprot.pdb")]})
+    monkeypatch.setattr(
+        M,
+        "session",
+        _FakeSession(
+            {
+                "rcpType": "protRcp",
+                "prot_ff": "leaprc.protein.ff19SB",
+                "nmLig": False,
+                "spLig": False,
+                "addType": "addWater",
+                "boxType": "cube",
+                "dist": "10",
+                "water_ff": "tip3p",
+                "pos_ion": "Na+",
+                "neg_ion": "Cl-",
+                "ionConc": "0.15",
+            }
+        ),
+    )
+    script = M.createAmberBashScript()
+    # The awk filter must still appear for the existing protRcp branch.
+    assert "awk" in script
+    # None of the glycoprotein-specific machinery should appear.
+    assert "_glyco_rename" not in script
+    assert "tleap.bonds.txt" not in script
+    assert "glycan_ff" not in script
+
+
+def test_setAmberOptions_glycoprotRcp_does_not_500_via_flask_client():
+    """Regression: previously stored rename_map (with tuple keys) in Flask
+    session, which raised TypeError on JSON serialisation -> 500 to the
+    user. Drive the full route via the test client and assert HTTP 200.
+    """
+    import io
+
+    pdb_body = textwrap.dedent("""\
+        ATOM      1  N   ASN A 250      10.000  10.000  10.000  1.00  0.00           N
+        ATOM      6  ND2 ASN A 250      13.500   9.134  10.000  1.00  0.00           N
+        HETATM    7  C1  NAG A 600      14.800   8.700  10.000  1.00  0.00           C
+        HETATM    8  O4  NAG A 600      15.800   9.700  10.000  1.00  0.00           O
+        CONECT    6    7
+        END
+        """)
+
+    client = M.app.test_client()
+    resp = client.post(
+        "/setAmberOptions",
+        data={
+            "rcpType": "glycoprotRcp",
+            "glycoprot_prot_ff": "leaprc.protein.ff14SB",
+            "glycoprot_glycan_ff": "leaprc.GLYCAM_06j-1",
+            "addType": "addWater",
+            "boxType": "cube",
+            "dist": "10",
+            "water_ff": "tip3p",
+            "pos_ion": "Na+",
+            "neg_ion": "Cl-",
+            "ionConc": "0.15",
+            "glycoprotFile": (io.BytesIO(pdb_body.encode()), "tinyglyco.pdb"),
+        },
+        content_type="multipart/form-data",
+    )
+
+    assert resp.status_code == 200, f"Got HTTP {resp.status_code}: {resp.data[:200]!r}"
+    body = resp.data.decode("utf-8", "replace")
+    assert "Internal Server Error" not in body
+    assert "0YB" in body  # detection actually ran
+    assert "glycan_ff=leaprc.GLYCAM_06j-1" in body

--- a/openmmdl/tests/openmmdl_simulation/test_glycan_imaging.py
+++ b/openmmdl/tests/openmmdl_simulation/test_glycan_imaging.py
@@ -1,0 +1,106 @@
+"""Tests for the glycan-aware PBC imaging helpers in post_md_conversions."""
+
+import numpy as np
+import pytest
+
+# requires MDAnalysis + mdtraj (mdtraj is imported by post_md_conversions)
+mda = pytest.importorskip("MDAnalysis")
+pytest.importorskip("mdtraj")
+
+from openmmdl.openmmdl_simulation.scripts.post_md_conversions import (  # noqa: E402
+    residues_bonded_to_protein,
+)
+
+
+def _build_synthetic_universe():
+    """Build a tiny in-memory MDAnalysis Universe consisting of:
+
+    * One Asn residue (atoms N, CA, CB, CG, OD1, ND2)
+    * One NAG sugar residue (single C1 atom for compactness)
+    * A bond between ND2 and C1 to simulate the N-glycosidic linkage
+    * A floating water residue (HOH O) to verify non-bonded non-protein
+      atoms are *not* picked up by ``residues_bonded_to_protein``
+    """
+    n_atoms = 6 + 1 + 1  # Asn + NAG + water
+    u = mda.Universe.empty(
+        n_atoms=n_atoms,
+        n_residues=3,
+        atom_resindex=[0] * 6 + [1] + [2],
+        residue_segindex=[0, 0, 0],
+        trajectory=True,
+    )
+    u.add_TopologyAttr("name", ["N", "CA", "CB", "CG", "OD1", "ND2", "C1", "O"])
+    u.add_TopologyAttr("resname", ["ASN", "NAG", "HOH"])
+    u.add_TopologyAttr("resid", [1, 2, 3])
+    u.add_TopologyAttr("segid", ["A"])
+
+    coords = np.array(
+        [
+            [0.0, 0.0, 0.0],  # N
+            [1.0, 0.0, 0.0],  # CA
+            [2.0, 0.0, 0.0],  # CB
+            [3.0, 0.0, 0.0],  # CG
+            [3.5, 0.7, 0.0],  # OD1
+            [3.5, -0.7, 0.0],  # ND2
+            [4.7, -1.0, 0.0],  # NAG.C1
+            [9.0, 9.0, 9.0],  # HOH.O (far away)
+        ],
+        dtype=np.float32,
+    )
+    u.atoms.positions = coords
+    # Bond ND2 (index 5) <-> NAG.C1 (index 6)
+    u.add_bonds([(5, 6)])
+    return u
+
+
+def test_residues_bonded_to_protein_finds_glycan():
+    u = _build_synthetic_universe()
+    glycan = residues_bonded_to_protein(u)
+    assert glycan.n_atoms == 1
+    assert glycan[0].resname == "NAG"
+
+
+def test_residues_bonded_to_protein_excludes_unbonded_residues():
+    u = _build_synthetic_universe()
+    glycan = residues_bonded_to_protein(u)
+    resnames = {a.resname for a in glycan}
+    assert "HOH" not in resnames
+    assert "ASN" not in resnames
+
+
+def test_residues_bonded_to_protein_empty_when_no_bonds():
+    # Same atom layout but no bonds at all.
+    u = mda.Universe.empty(
+        n_atoms=2,
+        n_residues=2,
+        atom_resindex=[0, 1],
+        residue_segindex=[0, 0],
+        trajectory=True,
+    )
+    u.add_TopologyAttr("name", ["ND2", "C1"])
+    u.add_TopologyAttr("resname", ["ASN", "NAG"])
+    u.add_TopologyAttr("resid", [1, 2])
+    u.add_TopologyAttr("segid", ["A"])
+    u.atoms.positions = np.array([[0, 0, 0], [1, 0, 0]], dtype=np.float32)
+    # No add_bonds call.
+    glycan = residues_bonded_to_protein(u)
+    assert glycan.n_atoms == 0
+
+
+def test_residues_bonded_to_protein_handles_no_protein():
+    # Universe with only sugar residues -> protein selection is empty.
+    u = mda.Universe.empty(
+        n_atoms=2,
+        n_residues=2,
+        atom_resindex=[0, 1],
+        residue_segindex=[0, 0],
+        trajectory=True,
+    )
+    u.add_TopologyAttr("name", ["C1", "C1"])
+    u.add_TopologyAttr("resname", ["NAG", "NAG"])
+    u.add_TopologyAttr("resid", [1, 2])
+    u.add_TopologyAttr("segid", ["A"])
+    u.atoms.positions = np.array([[0, 0, 0], [1, 0, 0]], dtype=np.float32)
+    u.add_bonds([(0, 1)])
+    glycan = residues_bonded_to_protein(u)
+    assert glycan.n_atoms == 0


### PR DESCRIPTION
Native support for N-/O-glycosylated proteins in the **OpenMMDL Setup AMBER path**. A glycoprotein PDB (protein with covalently attached glycans) can now be taken to a runnable MD system directly, without an external preparation step.

  ## Motivation

  Neither existing path handles glycoproteins today:

  - **PDB path** — OpenMM's bundled force-field XMLs carry no GLYCAM templates, so `createSystem` fails with `No template found for residue NAG`.
  - **AMBER path** — only one receptor force field is sourced, and no `bond` statements are emitted, so the protein–glycan linkages are lost.

  ## Changes

  **New `openmmdl/openmmdl_setup/glycoprotein.py`** — glycan detection and
  GLYCAM renaming:

  - Detects sugar residues by PDB Chemical Component Dictionary name
    (NAG, NDG, BMA, MAN, FUC, FUL).
  - Finds protein–glycan and glycan–glycan linkages from `CONECT`
    records, with a distance-based fallback when they are absent.
  - Maps residues and atoms to GLYCAM-06j-1 conventions (e.g.
    `NAG → 0YB`/`4YB`, glycosylated `ASN → NLN`).

  **`glycoprotRcp` receptor type** in the AMBER script generation:

  - Sources both the protein force field and the GLYCAM carbohydrate
    force field.
  - Emits an explicit `bond` statement for every glycosidic linkage so
    they survive into the generated topology.
  - Cleans the GLYCAM-renamed structure with `pdb4amber --no-reduce`.

  **Glycan-aware PBC imaging** in `post_md_conversions.py` — keeps glycans
  in the same periodic image as the protein residue they are bonded to
  during trajectory re-imaging.

  **UI** — a "Glycoprotein" option in the Amber Setup receptor tab.

  ## Scope and limitations

  Supports the common N-glycan core sugars listed above. The GLYCAM
  residue codes, linkage codes and atom-name maps were verified against
  the GLYCAM-06j-1 prep/lib files in
  [GLYCAM-Web/gmml](https://github.com/GLYCAM-Web/gmml). Sugars or
  linkage patterns outside the verified set raise a descriptive
  `NotImplementedError` rather than producing an incorrect topology —
  extending coverage is a matter of adding verified table entries.

  PDB-path (OpenMM XML) glycoprotein support would require custom
  residue templates and is left as future work.

  ## Testing

  32 new tests under `openmmdl/tests/` — unit tests for detection and
  renaming, an integration test for the generated AMBER script, and an
  analysis test for the imaging helper. The full pipeline was verified
  end-to-end on a four-chain N-glycosylated factor XIa system:
  detection → tleap topology generation → OpenMM minimization and MD ran